### PR TITLE
Fix compiler crash when casting to invalid type

### DIFF
--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -7819,6 +7819,12 @@ static IrInstruction *ir_analyze_cast(IrAnalyze *ira, IrInstruction *source_inst
 static IrInstruction *ir_implicit_cast(IrAnalyze *ira, IrInstruction *value, TypeTableEntry *expected_type) {
     assert(value);
     assert(value != ira->codegen->invalid_instruction);
+    if(expected_type && type_is_invalid(expected_type)) {
+        ir_add_error(ira, value,
+                buf_sprintf("type '%s' is invalid",
+                    buf_ptr(&expected_type->name)));
+            return ira->codegen->invalid_instruction;
+    };
     assert(!expected_type || !type_is_invalid(expected_type));
     assert(value->value.type);
     assert(!type_is_invalid(value->value.type));


### PR DESCRIPTION
Sometimes when the compiler can't find the type for a field in a struct, it'll crash with an assertion error:

```
zig: /home/raulgrell/Dev/zig/src/ir.cpp:7822: IrInstruction* ir_implicit_cast(IrAnalyze*, IrInstruction*, TypeTableEntry*): Assertion `!expected_type || !type_is_invalid(expected_type)' failed.
```

This solution does not fix the underlying problem, but shows which type is causing the error so it can be fixed. I can't for the life of me figure out how to reproduce it with a simple example, so I can't offer more than this paliative measure.

The error is renderered as:

```
/home/raulgrell/Projects/Zig/tick/src/engine/entity.zig:14:22: error: no member named 'ArrayList' in '/home/raulgrell/Projects/Zig/tick/lib/index.zig'
const ArrayList = lib.ArrayList;
                     ^
/home/raulgrell/Projects/Zig/tick/games/test.zig:68:43: error: type 'Controller' is invalid
var AGENT_CONTROLLER: entity.Controller = undefined;

```

where `Controller` is a struct which contains an `ArrayList` field. This is my own implemetation, not the one in the stdlib.