### PR TITLE
Correct floating-point literal allowed ranges

### DIFF
--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -3704,7 +3704,7 @@ static IrInstruction *ir_gen_float_lit(IrBuilder *irb, Scope *scope, AstNode *no
     assert(node->type == NodeTypeFloatLiteral);
 
     if (node->data.float_literal.overflow) {
-        add_node_error(irb->codegen, node, buf_sprintf("float literal too large to be represented in any type"));
+        add_node_error(irb->codegen, node, buf_sprintf("float literal out of range of any type"));
         return irb->codegen->invalid_instruction;
     }
 

--- a/src/tokenizer.cpp
+++ b/src/tokenizer.cpp
@@ -333,7 +333,7 @@ static void end_float_token(Tokenize *t) {
         } else {
             int significand_magnitude_in_bin = __builtin_clzll(1) - __builtin_clzll(significand);
             t->exponent_in_bin_or_dec += significand_magnitude_in_bin;
-            if (!(-1023 <= t->exponent_in_bin_or_dec && t->exponent_in_bin_or_dec < 1023)) {
+            if (!(-1022 <= t->exponent_in_bin_or_dec && t->exponent_in_bin_or_dec <= 1023)) {
                 t->cur_tok->data.float_lit.overflow = true;
                 return;
             } else {

--- a/test/cases/math.zig
+++ b/test/cases/math.zig
@@ -251,3 +251,9 @@ test "allow signed integer division/remainder when values are comptime known and
 test "float literal parsing" {
     comptime assert(0x1.0 == 1.0);
 }
+
+test "hex float literal within range" {
+    const a = 0x1.0p1023;
+    const b = 0x0.1p1027;
+    const c = 0x1.0p-1022;
+}

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -1931,4 +1931,18 @@ pub fn addCases(cases: &tests.CompileErrorContext) {
         \\}
     ,
         ".tmp_source.zig:1:13: error: struct 'Foo' contains itself");
+
+    cases.add("float literal too large error",
+        \\comptime {
+        \\    const a = 0x1.0p1024;
+        \\}
+    ,
+        ".tmp_source.zig:2:15: error: float literal out of range of any type");
+
+    cases.add("float literal too small error (denormal)",
+        \\comptime {
+        \\    const a = 0x1.0p-1023;
+        \\}
+    ,
+        ".tmp_source.zig:2:15: error: float literal out of range of any type");
 }


### PR DESCRIPTION
The exponent range for floating-point values is [-1022, 1023].

Fixes #399.

One note is that we consider floating point denormals to be invalid whereas something like C will allow them. Since we default to ffast-math-like behaviour this makes sense to issue an error where we would otherwise truncate.

As a result, I changed the resulting error message to be general over overflow and underflow/truncation. Feel free to reword it.