### PR TITLE
Switched find order for llvm, means it will choose llvm version 5.0 b…

### DIFF
--- a/cmake/Findllvm.cmake
+++ b/cmake/Findllvm.cmake
@@ -8,7 +8,7 @@
 # LLVM_LIBDIRS
 
 find_program(LLVM_CONFIG_EXE
-    NAMES llvm-config llvm-config-5.0
+    NAMES llvm-config-5.0 llvm-config
     PATHS
         "/mingw64/bin"
         "/c/msys64/mingw64/bin"


### PR DESCRIPTION
…efore any other version.