### PR TITLE
c macros: support hex chars

### DIFF
--- a/src/c_tokenizer.cpp
+++ b/src/c_tokenizer.cpp
@@ -632,28 +632,12 @@ void tokenize_c_macro(CTokenize *ctok, const uint8_t *c) {
                         ctok->cur_char = (uint8_t)(ctok->cur_char + (uint8_t)(*c - '0'));
                         ctok->octal_index += 1;
                         if (ctok->octal_index == 3) {
-                            if (ctok->cur_tok->id == CTokIdStrLit) {
-                                add_char(ctok, ctok->cur_char);
-                                ctok->state = CTokStateString;
-                            } else if (ctok->cur_tok->id == CTokIdCharLit) {
-                                ctok->cur_tok->data.char_lit = ctok->cur_char;
-                                ctok->state = CTokStateExpectEndQuot;
-                            } else {
-                                zig_unreachable();
-                            }
+                            add_char(ctok, ctok->cur_char);
                         }
                         break;
                     default:
                         c -= 1;
-                        if (ctok->cur_tok->id == CTokIdStrLit) {
-                            add_char(ctok, ctok->cur_char);
-                            ctok->state = CTokStateString;
-                        } else if (ctok->cur_tok->id == CTokIdCharLit) {
-                            ctok->cur_tok->data.char_lit = ctok->cur_char;
-                            ctok->state = CTokStateExpectEndQuot;
-                        } else {
-                            zig_unreachable();
-                        }
+                        add_char(ctok, ctok->cur_char);
                         continue;
                 }
                 break;

--- a/src/c_tokenizer.hpp
+++ b/src/c_tokenizer.hpp
@@ -68,6 +68,7 @@ enum CTokState {
     CTokStateExpSign,
     CTokStateFloatExp,
     CTokStateFloatExpFirst,
+    CTokStateStrHex,
     CTokStateStrOctal,
     CTokStateNumLitIntSuffixU,
     CTokStateNumLitIntSuffixL,

--- a/test/parsec.zig
+++ b/test/parsec.zig
@@ -285,6 +285,18 @@ pub fn addCases(cases: &tests.ParseCContext) {
         \\pub const @"comptime" = struct_comptime;
     );
 
+    cases.add("macro defines string literal with hex",
+        \\#define FOO "aoeu\xab derp"
+        \\#define FOO2 "aoeu\x0007a derp"
+        \\#define FOO_CHAR '\xfF'
+    ,
+        \\pub const FOO = c"aoeu\xab derp";
+    ,
+        \\pub const FOO2 = c"aoeuz derp";
+    ,
+        \\pub const FOO_CHAR = 255;
+    );
+
     cases.add("macro defines string literal with octal",
         \\#define FOO "aoeu\023 derp"
         \\#define FOO2 "aoeu\0234 derp"


### PR DESCRIPTION
Support hex escape sequence in character and string literals.

Limitation: only support 8-bit characters. If I am not mistaken, zig do not support wide char literals anyway.