### PR TITLE
Add dash arguments for cli

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,9 +20,9 @@ static int usage(const char *arg0) {
     fprintf(stderr, "Usage: %s [command] [options]\n"
         "Commands:\n"
         "  build                        build project from build.zig\n"
-        "  build_exe [source]           create executable from source or object files\n"
-        "  build_lib [source]           create library from source or object files\n"
-        "  build_obj [source]           create object from source or assembly\n"
+        "  build-exe [source]           create executable from source or object files\n"
+        "  build-lib [source]           create library from source or object files\n"
+        "  build-obj [source]           create object from source or assembly\n"
         "  parsec [source]              convert c code to zig code\n"
         "  targets                      list available compilation targets\n"
         "  test [source]                create and run a test build\n"
@@ -457,13 +457,13 @@ int main(int argc, char **argv) {
                 }
             }
         } else if (cmd == CmdInvalid) {
-            if (strcmp(arg, "build_exe") == 0) {
+            if (strcmp(arg, "build-exe") == 0) {
                 cmd = CmdBuild;
                 out_type = OutTypeExe;
-            } else if (strcmp(arg, "build_obj") == 0) {
+            } else if (strcmp(arg, "build-obj") == 0) {
                 cmd = CmdBuild;
                 out_type = OutTypeObj;
-            } else if (strcmp(arg, "build_lib") == 0) {
+            } else if (strcmp(arg, "build-lib") == 0) {
                 cmd = CmdBuild;
                 out_type = OutTypeLib;
             } else if (strcmp(arg, "version") == 0) {

--- a/std/build.zig
+++ b/std/build.zig
@@ -902,9 +902,9 @@ pub const LibExeObjStep = struct {
         defer zig_args.deinit();
 
         const cmd = switch (self.kind) {
-            Kind.Lib => "build_lib",
-            Kind.Exe => "build_exe",
-            Kind.Obj => "build_obj",
+            Kind.Lib => "build-lib",
+            Kind.Exe => "build-exe",
+            Kind.Obj => "build-obj",
         };
         %%zig_args.append(cmd);
 

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -535,7 +535,7 @@ pub const CompileErrorContext = struct {
             const obj_path = %%os.path.join(b.allocator, b.cache_root, "test.o");
 
             var zig_args = ArrayList([]const u8).init(b.allocator);
-            %%zig_args.append(if (self.case.is_exe) "build_exe" else "build_obj");
+            %%zig_args.append(if (self.case.is_exe) "build-exe" else "build-obj");
             %%zig_args.append(b.pathFromRoot(root_src));
 
             %%zig_args.append("--name");


### PR DESCRIPTION
Rationale is that typing a '_' is more work than a '-' and I can't think of an explicit reason why to prefer the former. Both are still accepted however for compatibility.