### PR TITLE
Fix isatty for macOS and libc

### DIFF
--- a/std/io.zig
+++ b/std/io.zig
@@ -181,7 +181,7 @@ pub const OutStream = struct {
     pub fn isTty(self: &OutStream) -> %bool {
         if (is_posix) {
             if (builtin.link_libc) {
-                return c.isatty(self.fd) == 0;
+                return c.isatty(self.fd) != 0;
             } else {
                 return system.isatty(self.fd);
             }
@@ -435,7 +435,7 @@ pub const InStream = struct {
     pub fn isTty(self: &InStream) -> %bool {
         if (is_posix) {
             if (builtin.link_libc) {
-                return c.isatty(self.fd) == 0;
+                return c.isatty(self.fd) != 0;
             } else {
                 return system.isatty(self.fd);
             }

--- a/std/os/darwin.zig
+++ b/std/os/darwin.zig
@@ -125,7 +125,7 @@ pub fn exit(code: i32) -> noreturn {
 }
 
 pub fn isatty(fd: i32) -> bool {
-    c.isatty(fd) == 0
+    c.isatty(fd) != 0
 }
 
 pub fn fstat(fd: i32, buf: &c.stat) -> usize {


### PR DESCRIPTION
The POSIX function returns 1 for true and 0 for false, but Zig used `==`.