### PR TITLE
Add c allocator

### DIFF
--- a/std/c/index.zig
+++ b/std/c/index.zig
@@ -43,3 +43,7 @@ pub extern "c" fn sigaction(sig: c_int, noalias act: &const Sigaction, noalias o
 pub extern "c" fn nanosleep(rqtp: &const timespec, rmtp: ?&timespec) -> c_int;
 pub extern "c" fn setreuid(ruid: c_uint, euid: c_uint) -> c_int;
 pub extern "c" fn setregid(rgid: c_uint, egid: c_uint) -> c_int;
+
+pub extern "c" fn malloc(usize) -> ?&c_void;
+pub extern "c" fn realloc(&c_void, usize) -> ?&c_void;
+pub extern "c" fn free(&c_void);


### PR DESCRIPTION
Did consider adding a better `@compileError` if we weren't linking with libc. Thoughts on that?

Also, am I right in thinking that a local `cInclude` will be preferred within the functions as they will be compiled out and the include will not be performed at all? Just considering the platforms which may not have an include directory set up properly (or assuming no c present).