### PR TITLE
Improved printing for floats

### DIFF
--- a/std/fmt/errol/index.zig
+++ b/std/fmt/errol/index.zig
@@ -38,7 +38,7 @@ fn errol3u(val: f64, buffer: []u8) -> FloatDecimal {
         return errolFixed(val, buffer);
     }
 
-    
+
     // normalize the midpoint
 
     const e = math.frexp(val).exponent;
@@ -138,7 +138,7 @@ fn tableLowerBound(k: u64) -> usize {
 
     while (j < enum3.len) {
         if (enum3[j] < k) {
-            j = 2 * k + 2;
+            j = 2 * j + 2;
         } else {
             i = j;
             j = 2 * j + 1;
@@ -217,7 +217,7 @@ fn hpMul10(hp: &HP) {
 
     hp.val *= 10.0;
     hp.off *= 10.0;
-    
+
     var off = hp.val;
     off -= val * 8.0;
     off -= val * 2.0;
@@ -241,7 +241,7 @@ fn errolInt(val: f64, buffer: []u8) -> FloatDecimal {
     var low: u128 = mid - fpeint((fpnext(val) - val) / 2.0);
     var high: u128 = mid + fpeint((val - fpprev(val)) / 2.0);
 
-    if (@bitCast(u64, val) & 0x1 != 0) { 
+    if (@bitCast(u64, val) & 0x1 != 0) {
         high -= 1;
     } else {
         low -= 1;
@@ -347,11 +347,11 @@ fn errolFixed(val: f64, buffer: []u8) -> FloatDecimal {
 }
 
 fn fpnext(val: f64) -> f64 {
-    return @bitCast(f64, @bitCast(u64, val) + 1);
+    return @bitCast(f64, @bitCast(u64, val) +% 1);
 }
 
 fn fpprev(val: f64) -> f64 {
-    return @bitCast(f64, @bitCast(u64, val) - 1);
+    return @bitCast(f64, @bitCast(u64, val) -% 1);
 }
 
 pub const c_digits_lut = []u8 {

--- a/std/fmt/errol/index.zig
+++ b/std/fmt/errol/index.zig
@@ -32,7 +32,7 @@ pub fn errol3(value: f64, buffer: []u8) -> FloatDecimal {
 fn errol3u(val: f64, buffer: []u8) -> FloatDecimal {
     // check if in integer or fixed range
 
-    if (val >= 9.007199254740992e15 and val < 3.40282366920938e+38) {
+    if (val > 9.007199254740992e15 and val < 3.40282366920938e+38) {
         return errolInt(val, buffer);
     } else if (val >= 16.0 and val < 9.007199254740992e15) {
         return errolFixed(val, buffer);
@@ -235,7 +235,7 @@ fn hpMul10(hp: &HP) {
 fn errolInt(val: f64, buffer: []u8) -> FloatDecimal {
     const pow19 = u128(1e19);
 
-    assert((val >= 9.007199254740992e15) and val < (3.40282366920938e38));
+    assert((val > 9.007199254740992e15) and val < (3.40282366920938e38));
 
     var mid = u128(val);
     var low: u128 = mid - fpeint((fpnext(val) - val) / 2.0);
@@ -510,10 +510,6 @@ fn u64toa(value_param: u64, buffer: []u8) -> usize {
         buf_index += 1;
         buffer[buf_index] = c_digits_lut[d8];
         buf_index += 1;
-        buffer[buf_index] = c_digits_lut[d8];
-        buf_index += 1;
-        buffer[buf_index] = c_digits_lut[d8];
-        buf_index += 1;
         buffer[buf_index] = c_digits_lut[d8 + 1];
         buf_index += 1;
     } else {
@@ -613,7 +609,7 @@ fn fpeint(from: f64) -> u128 {
     const bits = @bitCast(u64, from);
     assert((bits & ((1 << 52) - 1)) == 0);
 
-    return u64(1) << u6(((bits >> 52) - 1023));
+    return u128(1) << @truncate(u7, (bits >> 52) -% 1023);
 }
 
 

--- a/std/fmt/index.zig
+++ b/std/fmt/index.zig
@@ -244,30 +244,46 @@ pub fn formatBuf(buf: []const u8, width: usize,
 }
 
 pub fn formatFloat(value: var, context: var, output: fn(@typeOf(context), []const u8)->bool) -> bool {
-    var buffer: [20]u8 = undefined;
-    const float_decimal = errol3(f64(value), buffer[0..]);
-    if (float_decimal.exp != 0) {
-        if (!output(context, float_decimal.digits[0..1]))
-            return false;
-    } else {
-        if (!output(context, "0"))
-            return false;
+    var x = f64(value);
+
+    // Errol doesn't handle these special cases.
+    if (math.isNan(x)) {
+        return output(context, "NaN");
     }
+    if (math.isPositiveInf(x)) {
+        return output(context, "Infinity");
+    }
+    if (math.isNegativeInf(x)) {
+        return output(context, "-Infinity");
+    }
+    if (x == 0.0) {
+        return output(context, "0.0");
+    }
+    if (x < 0.0) {
+        if (!output(context, "-"))
+            return false;
+        x = -x;
+    }
+
+    var buffer: [32]u8 = undefined;
+    const float_decimal = errol3(x, buffer[0..]);
+    if (!output(context, float_decimal.digits[0..1]))
+        return false;
     if (!output(context, "."))
         return false;
     if (float_decimal.digits.len > 1) {
-        const start = if (float_decimal.exp == 0) usize(0) else usize(1);
-        if (!output(context, float_decimal.digits[start .. math.min(usize(7), float_decimal.digits.len)]))
+        const num_digits = if (@typeOf(value) == f32) { usize(8) } else { usize(17) };
+        if (!output(context, float_decimal.digits[1 .. math.min(num_digits, float_decimal.digits.len)]))
             return false;
     } else {
         if (!output(context, "0"))
             return false;
     }
 
-    if (float_decimal.exp != 1 and float_decimal.exp != 0) {
+    if (float_decimal.exp != 1) {
         if (!output(context, "e"))
             return false;
-        if (!formatInt(float_decimal.exp, 10, false, 0, context, output))
+        if (!formatInt(float_decimal.exp - 1, 10, false, 0, context, output))
             return false;
     }
     return true;

--- a/std/fmt/index.zig
+++ b/std/fmt/index.zig
@@ -250,19 +250,16 @@ pub fn formatFloat(value: var, context: var, output: fn(@typeOf(context), []cons
     if (math.isNan(x)) {
         return output(context, "NaN");
     }
-    if (math.isPositiveInf(x)) {
-        return output(context, "Infinity");
-    }
-    if (math.isNegativeInf(x)) {
-        return output(context, "-Infinity");
-    }
-    if (x == 0.0) {
-        return output(context, "0.0");
-    }
-    if (x < 0.0) {
+    if (math.signbit(x)) {
         if (!output(context, "-"))
             return false;
         x = -x;
+    }
+    if (math.isPositiveInf(x)) {
+        return output(context, "Infinity");
+    }
+    if (x == 0.0) {
+        return output(context, "0.0");
     }
 
     var buffer: [32]u8 = undefined;
@@ -272,8 +269,12 @@ pub fn formatFloat(value: var, context: var, output: fn(@typeOf(context), []cons
     if (!output(context, "."))
         return false;
     if (float_decimal.digits.len > 1) {
-        const num_digits = if (@typeOf(value) == f32) { usize(8) } else { usize(17) };
-        if (!output(context, float_decimal.digits[1 .. math.min(num_digits, float_decimal.digits.len)]))
+        const num_digits = if (@typeOf(value) == f32) {
+            math.min(usize(9), float_decimal.digits.len)
+        } else {
+            float_decimal.digits.len
+        };
+        if (!output(context, float_decimal.digits[1 .. num_digits]))
             return false;
     } else {
         if (!output(context, "0"))


### PR DESCRIPTION
All floats I've tried now print correctly.

See https://github.com/zig-lang/zig/issues/375#issuecomment-338805713 for the first commit. The further changes are

* -0.0 now prints correctly, thanks @tiehuis 
* you actually need 9 digits for f32s (I think 8 would be enough if you used the next digit to round, but if there's a lot of 9s at the end you'd need to carry and it'd be a pain); for f64s, I just use the whole buffer Errol outputs
* fixed some more small typos in our Errol code
* Errol has a bug, possibly? See https://github.com/marcandrysco/Errol/issues/8. I had to make the change I mentioned in that issue to get the tests to succeed.

For the last bullet, maybe we want to wait for an upstream confirmation and patch.

## Tests

The tests I made are [here](https://gist.github.com/scurest/89078cd04a0cbbb7a8e8bec77577fca7) (see the `usage` file at the bottom). All the tests I've run have passed. In particular the f32 tests are intended to show by exhaustion that we're correct for all f32s.

* **f32** I iterate over all positive u32s, bitCasting them to f32s, skipping the NaNs and Infs, and printing the rest to stdout in zig. This is piped into a C program where I scanf with `%f` and check if the nth one I get bitcasts back to n. This should exhaustively test all positive f32s.

    If you want to check all f32s, just change the 0x80000000s to 0xffffffffs in both files. I didn't just because it takes about 2 hours to run already. 

* **rand** This generates some random numbers with xoroshiro128+, bitcasts to f64, prints them, pipes them into C, scanfs them with `%lf` and checks if their the same. The more times you run it, the greater your confidence should be that we're correct :)