### PR TITLE
Enforce "\n" line endings on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.zig text eol=lf


### PR DESCRIPTION
With Windows line endings, which seems to be the default on Windows, the
zig compiler won't understand std out of the box. This project should
not rely on git's global core.autocrlf setting.