### PR TITLE
Add emit command-line option

### DIFF
--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -1366,6 +1366,12 @@ enum BuildMode {
     BuildModeSafeRelease,
 };
 
+enum EmitFileType {
+    EmitFileTypeBinary,
+    EmitFileTypeAssembly,
+    EmitFileTypeLLVMIr,
+};
+
 struct LinkLib {
     Buf *name;
     Buf *path;
@@ -1449,6 +1455,7 @@ struct CodeGen {
         TypeTableEntry *entry_arg_tuple;
     } builtin_types;
 
+    EmitFileType emit_file_type;
     ZigTarget zig_target;
     LLVMTargetDataRef target_data_ref;
     unsigned pointer_size_bytes;

--- a/src/codegen.hpp
+++ b/src/codegen.hpp
@@ -23,6 +23,7 @@ void codegen_set_llvm_argv(CodeGen *codegen, const char **args, size_t len);
 void codegen_set_is_test(CodeGen *codegen, bool is_test);
 void codegen_set_each_lib_rpath(CodeGen *codegen, bool each_lib_rpath);
 
+void codegen_set_emit_file_type(CodeGen *g, EmitFileType emit_file_type);
 void codegen_set_is_static(CodeGen *codegen, bool is_static);
 void codegen_set_strip(CodeGen *codegen, bool strip);
 void codegen_set_errmsg_color(CodeGen *codegen, ErrColor err_color);

--- a/src/target.cpp
+++ b/src/target.cpp
@@ -555,6 +555,14 @@ const char *target_o_file_ext(ZigTarget *target) {
     }
 }
 
+const char *target_asm_file_ext(ZigTarget *target) {
+    return ".s";
+}
+
+const char *target_llvm_ir_file_ext(ZigTarget *target) {
+    return ".ll";
+}
+
 const char *target_exe_file_ext(ZigTarget *target) {
     if (target->os == ZigLLVM_Win32) {
         return ".exe";

--- a/src/target.hpp
+++ b/src/target.hpp
@@ -73,6 +73,8 @@ void resolve_target_object_format(ZigTarget *target);
 uint32_t target_c_type_size_in_bits(const ZigTarget *target, CIntType id);
 
 const char *target_o_file_ext(ZigTarget *target);
+const char *target_asm_file_ext(ZigTarget *target);
+const char *target_llvm_ir_file_ext(ZigTarget *target);
 const char *target_exe_file_ext(ZigTarget *target);
 
 Buf *target_dynamic_linker(ZigTarget *target);

--- a/src/zig_llvm.hpp
+++ b/src/zig_llvm.hpp
@@ -34,8 +34,16 @@ void ZigLLVMInitializeLowerIntrinsicsPass(LLVMPassRegistryRef R);
 char *ZigLLVMGetHostCPUName(void);
 char *ZigLLVMGetNativeFeatures(void);
 
+// We use a custom enum here since LLVM does not expose LLVMIr as an emit
+// output through the same mechanism as assembly/binary.
+enum ZigLLVM_EmitOutputType {
+    ZigLLVM_EmitAssembly,
+    ZigLLVM_EmitBinary,
+    ZigLLVM_EmitLLVMIr,
+};
+
 bool ZigLLVMTargetMachineEmitToFile(LLVMTargetMachineRef targ_machine_ref, LLVMModuleRef module_ref,
-        const char *filename, LLVMCodeGenFileType file_type, char **error_message, bool is_debug);
+        const char *filename, ZigLLVM_EmitOutputType output_type, char **error_message, bool is_debug);
 
 LLVMValueRef ZigLLVMBuildCall(LLVMBuilderRef B, LLVMValueRef Fn, LLVMValueRef *Args,
         unsigned NumArgs, unsigned CC, bool always_inline, const char *Name);


### PR DESCRIPTION
The only change versus the previous commit is adding an enum to `zig_llvm.hpp` to pass along the type we want to emit. This is a bit clearer than the former (quite ugly) method of using another boolean parameter.

Adds output generation for the following formats:
 - binary
 - assembly
 - llvm ir

Closes #571.