### PR TITLE
Allow Windows line endings

### DIFF
--- a/src/c_tokenizer.cpp
+++ b/src/c_tokenizer.cpp
@@ -12,6 +12,7 @@
          ' ': \
     case '\t': \
     case '\v': \
+    case '\r': \
     case '\f'
 
 #define DIGIT_NON_ZERO \

--- a/src/tokenizer.cpp
+++ b/src/tokenizer.cpp
@@ -17,7 +17,8 @@
 
 #define WHITESPACE \
          ' ': \
-    case '\n'
+    case '\n': \
+    case '\r'
 
 #define DIGIT_NON_ZERO \
          '1': \
@@ -440,9 +441,7 @@ static const char* get_escape_shorthand(uint8_t c) {
 }
 
 static void invalid_char_error(Tokenize *t, uint8_t c) {
-    if (c == '\r') {
-        tokenize_error(t, "invalid carriage return, only '\\n' line endings are supported");
-    } else if (isprint(c)) {
+    if (isprint(c)) {
         tokenize_error(t, "invalid character: '%c'", c);
     } else {
         const char *sh = get_escape_shorthand(c);


### PR DESCRIPTION
Treat '\r' as whitespace in the zig and the C tokenizer.