### PR TITLE
Win32 libc runtime fixes.

### DIFF
--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -3440,8 +3440,14 @@ void find_libc_lib_path(CodeGen *g) {
             zig_panic("Unable to determine libc lib path.");
         }
     }
+
     if (!g->libc_static_lib_dir || buf_len(g->libc_static_lib_dir) == 0) {
-        zig_panic("Unable to determine libc static lib path.");
+        if ((g->zig_target.os == ZigLLVM_Win32) && (g->msvc_lib_dir != NULL)) {
+            return;
+        }
+        else {
+            zig_panic("Unable to determine libc static lib path.");
+        }
     }
 }
 


### PR DESCRIPTION
This fixes a minor issue introduced by this commit: [abff1b6](https://github.com/zig-lang/zig/commit/abff1b688420eb30d98145d8bc48e7d08f259885)

With the current master code, if you try to link with '--library c' but don't specify an explicit libc_static_lib_dir, it will fail. Windows doesn't have a separate libc_static_lib_dir and it's already accounted for by msvc_lib_dir. 