### PR TITLE
Fix typos in std.io

### DIFF
--- a/std/io.zig
+++ b/std/io.zig
@@ -308,7 +308,7 @@ pub const InStream = struct {
     readFn: fn(self: &InStream, buffer: []u8) -> %usize,
 
     /// Replaces `buffer` contents by reading from the stream until it is finished.
-    /// If `buffer.len()` woould exceed `max_size`, `error.StreamTooLong` is returned and
+    /// If `buffer.len()` would exceed `max_size`, `error.StreamTooLong` is returned and
     /// the contents read from the stream are lost.
     pub fn readAllBuffer(self: &InStream, buffer: &Buffer, max_size: usize) -> %void {
         %return buffer.resize(0);
@@ -339,7 +339,7 @@ pub const InStream = struct {
         var buf = Buffer.initNull(allocator);
         defer buf.deinit();
 
-        %return self.readAllBuffer(self, &buf, max_size);
+        %return self.readAllBuffer(&buf, max_size);
         return buf.toOwnedSlice();
     }
 


### PR DESCRIPTION
The fix for `readAllAlloc` was tested with

```
$ cat hello.txt
hello
$ cat a.zig
const io = @import("std").io;
const mem = @import("std").mem;
const assert = @import("std").debug.assert;
const heap = @import("std").heap;
pub fn main() -> %void {
    var f = %return io.File.openRead("hello.txt", &heap.c_allocator);
    const in = &f.in_stream;
    const buf = %return in.readAllAlloc(&heap.c_allocator, 100);
    assert(mem.eql(u8, buf, "hello\n"));
}
$ zig build-exe --library c a.zig
$ ./a && echo $?
0
```