### PR TITLE
*WIP* error return trace proof of concept

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -10,7 +10,7 @@ const ArrayList = std.ArrayList;
 const Buffer = std.Buffer;
 const io = std.io;
 
-pub fn build(b: &Builder) {
+pub fn build(b: &Builder) -> %void {
     const mode = b.standardReleaseOptions();
 
     var docgen_exe = b.addExecutable("docgen", "doc/docgen.zig");
@@ -36,7 +36,7 @@ pub fn build(b: &Builder) {
     const test_step = b.step("test", "Run all the tests");
 
     // find the stage0 build artifacts because we're going to re-use config.h and zig_cpp library
-    const build_info = b.exec([][]const u8{b.zig_exe, "BUILD_INFO"});
+    const build_info = try b.exec([][]const u8{b.zig_exe, "BUILD_INFO"});
     var index: usize = 0;
     const cmake_binary_dir = nextValue(&index, build_info);
     const cxx_compiler = nextValue(&index, build_info);
@@ -68,7 +68,7 @@ pub fn build(b: &Builder) {
     dependOnLib(exe, llvm);
 
     if (exe.target.getOs() == builtin.Os.linux) {
-        const libstdcxx_path_padded = b.exec([][]const u8{cxx_compiler, "-print-file-name=libstdc++.a"});
+        const libstdcxx_path_padded = try b.exec([][]const u8{cxx_compiler, "-print-file-name=libstdc++.a"});
         const libstdcxx_path = ??mem.split(libstdcxx_path_padded, "\r\n").next();
         exe.addObjectFile(libstdcxx_path);
 
@@ -155,9 +155,9 @@ const LibraryDep = struct {
 };
 
 fn findLLVM(b: &Builder, llvm_config_exe: []const u8) -> %LibraryDep {
-    const libs_output = b.exec([][]const u8{llvm_config_exe, "--libs", "--system-libs"});
-    const includes_output = b.exec([][]const u8{llvm_config_exe, "--includedir"});
-    const libdir_output = b.exec([][]const u8{llvm_config_exe, "--libdir"});
+    const libs_output = try b.exec([][]const u8{llvm_config_exe, "--libs", "--system-libs"});
+    const includes_output = try b.exec([][]const u8{llvm_config_exe, "--includedir"});
+    const libdir_output = try b.exec([][]const u8{llvm_config_exe, "--libdir"});
 
     var result = LibraryDep {
         .libs = ArrayList([]const u8).init(b.allocator),

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -142,6 +142,7 @@
             <li><a href="#builtin-TagType">@TagType</a></li>
             <li><a href="#builtin-EnumTagType">@EnumTagType</a></li>
             <li><a href="#builtin-errorName">@errorName</a></li>
+            <li><a href="#builtin-errorReturnTrace">@errorReturnTrace</a></li>
             <li><a href="#builtin-fence">@fence</a></li>
             <li><a href="#builtin-fieldParentPtr">@fieldParentPtr</a></li>
             <li><a href="#builtin-frameAddress">@frameAddress</a></li>
@@ -4411,6 +4412,13 @@ test.zig:6:2: error: found compile log statement
       If there are no calls to <code>@errorName</code> in an entire application,
       or all calls have a compile-time known value for <code>err</code>, then no
       error name table will be generated.
+      </p>
+      <h3 id="builtin-errorReturnTrace">@errorReturnTrace</h3>
+      <pre><code class="zig">@errorReturnTrace() -&gt; ?&amp;builtin.StackTrace</code></pre>
+      <p>
+      If the binary is built with error return tracing, and this function is invoked in a
+      function that calls a function with an error or error union return type, returns a
+      stack trace object. Otherwise returns `null`.
       </p>
       <h3 id="builtin-fence">@fence</h3>
       <pre><code class="zig">@fence(order: AtomicOrder)</code></pre>

--- a/example/mix_o_files/build.zig
+++ b/example/mix_o_files/build.zig
@@ -1,6 +1,6 @@
 const Builder = @import("std").build.Builder;
 
-pub fn build(b: &Builder) {
+pub fn build(b: &Builder) -> %void {
     const obj = b.addObject("base64", "base64.zig");
 
     const exe = b.addCExecutable("test");

--- a/example/shared_library/build.zig
+++ b/example/shared_library/build.zig
@@ -1,6 +1,6 @@
 const Builder = @import("std").build.Builder;
 
-pub fn build(b: &Builder) {
+pub fn build(b: &Builder) -> %void {
     const lib = b.addSharedLibrary("mathtest", "mathtest.zig", b.version(1, 0, 0));
 
     const exe = b.addCExecutable("test");

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -1574,6 +1574,8 @@ struct CodeGen {
     size_t largest_err_name_len;
     LLVMValueRef safety_crash_err_fn;
 
+    LLVMValueRef return_err_fn;
+
     IrInstruction *invalid_instruction;
     ConstExprValue const_void_val;
 

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -1274,6 +1274,7 @@ enum BuiltinFnId {
     BuiltinFnIdSetAlignStack,
     BuiltinFnIdArgType,
     BuiltinFnIdExport,
+    BuiltinFnIdErrorReturnTrace,
 };
 
 struct BuiltinFnEntry {
@@ -1499,6 +1500,7 @@ struct CodeGen {
     Buf triple_str;
     BuildMode build_mode;
     bool is_test_build;
+    bool have_err_ret_tracing;
     uint32_t target_os_index;
     uint32_t target_arch_index;
     uint32_t target_environ_index;
@@ -1902,6 +1904,7 @@ enum IrInstructionId {
     IrInstructionIdSetAlignStack,
     IrInstructionIdArgType,
     IrInstructionIdExport,
+    IrInstructionIdErrorReturnTrace,
 };
 
 struct IrInstruction {
@@ -2721,6 +2724,10 @@ struct IrInstructionExport {
     IrInstruction *name;
     IrInstruction *linkage;
     IrInstruction *target;
+};
+
+struct IrInstructionErrorReturnTrace {
+    IrInstruction base;
 };
 
 static const size_t slice_ptr_index = 0;

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -1595,6 +1595,8 @@ struct CodeGen {
     ZigList<AstNode *> tld_ref_source_node_stack;
 
     TypeTableEntry *align_amt_type;
+    TypeTableEntry *stack_trace_type;
+    TypeTableEntry *ptr_to_stack_trace_type;
 };
 
 enum VarLinkage {

--- a/src/all_types.hpp
+++ b/src/all_types.hpp
@@ -1205,6 +1205,7 @@ struct FnTableEntry {
     uint32_t alignstack_value;
 
     ZigList<FnExport> export_list;
+    bool calls_errorable_function;
 };
 
 uint32_t fn_table_entry_hash(FnTableEntry*);
@@ -1530,6 +1531,7 @@ struct CodeGen {
     FnTableEntry *panic_fn;
     LLVMValueRef cur_ret_ptr;
     LLVMValueRef cur_fn_val;
+    LLVMValueRef cur_err_ret_trace_val;
     bool c_want_stdint;
     bool c_want_stdbool;
     AstNode *root_export_decl;

--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -869,7 +869,7 @@ static const char *calling_convention_fn_type_str(CallingConvention cc) {
     zig_unreachable();
 }
 
-static TypeTableEntry *get_ptr_to_stack_trace_type(CodeGen *g) {
+TypeTableEntry *get_ptr_to_stack_trace_type(CodeGen *g) {
     if (g->stack_trace_type == nullptr) {
         ConstExprValue *stack_trace_type_val = get_builtin_value(g, "StackTrace");
         assert(stack_trace_type_val->type->id == TypeTableEntryIdMetaType);
@@ -1191,6 +1191,9 @@ static TypeTableEntry *analyze_fn_type(CodeGen *g, AstNode *proto_node, Scope *c
         }
 
         TypeTableEntry *type_entry = analyze_type_expr(g, child_scope, param_node->data.param_decl.type);
+        if (type_is_invalid(type_entry)) {
+            return g->builtin_types.entry_invalid;
+        }
         if (fn_type_id.cc != CallingConventionUnspecified) {
             type_ensure_zero_bits_known(g, type_entry);
             if (!type_has_bits(type_entry)) {
@@ -2586,6 +2589,7 @@ static void wrong_panic_prototype(CodeGen *g, AstNode *proto_node, TypeTableEntr
 }
 
 static void typecheck_panic_fn(CodeGen *g, FnTableEntry *panic_fn) {
+    return; // TODO
     AstNode *proto_node = panic_fn->proto_node;
     assert(proto_node->type == NodeTypeFnProto);
     TypeTableEntry *fn_type = panic_fn->type_entry;

--- a/src/analyze.hpp
+++ b/src/analyze.hpp
@@ -187,6 +187,7 @@ void add_fn_export(CodeGen *g, FnTableEntry *fn_table_entry, Buf *symbol_name, G
 
 
 ConstExprValue *get_builtin_value(CodeGen *codegen, const char *name);
+TypeTableEntry *get_ptr_to_stack_trace_type(CodeGen *g);
 
 
 #endif

--- a/src/analyze.hpp
+++ b/src/analyze.hpp
@@ -185,4 +185,8 @@ PackageTableEntry *new_anonymous_package(void);
 Buf *const_value_to_buffer(ConstExprValue *const_val);
 void add_fn_export(CodeGen *g, FnTableEntry *fn_table_entry, Buf *symbol_name, GlobalLinkageId linkage, bool ccc);
 
+
+ConstExprValue *get_builtin_value(CodeGen *codegen, const char *name);
+
+
 #endif

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5444,6 +5444,7 @@ static void define_builtin_compile_vars(CodeGen *g) {
     buf_appendf(contents, "pub const object_format = ObjectFormat.%s;\n", cur_obj_fmt);
     buf_appendf(contents, "pub const mode = %s;\n", build_mode_to_str(g->build_mode));
     buf_appendf(contents, "pub const link_libc = %s;\n", bool_to_str(g->libc_link_lib != nullptr));
+    buf_appendf(contents, "pub const have_error_return_tracing = %s;\n", bool_to_str(g->have_err_ret_tracing));
 
     buf_appendf(contents, "pub const __zig_test_fn_slice = {}; // overwritten later\n");
 

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -8230,16 +8230,6 @@ static bool ir_resolve_comptime(IrAnalyze *ira, IrInstruction *value, bool *out)
     return ir_resolve_bool(ira, value, out);
 }
 
-static ConstExprValue *get_builtin_value(CodeGen *codegen, const char *name) {
-    Tld *tld = codegen->compile_var_import->decls_scope->decl_table.get(buf_create_from_str(name));
-    resolve_top_level_decl(codegen, tld, false, nullptr);
-    assert(tld->id == TldIdVar);
-    TldVar *tld_var = (TldVar *)tld;
-    ConstExprValue *var_value = tld_var->var->value;
-    assert(var_value != nullptr);
-    return var_value;
-}
-
 static bool ir_resolve_atomic_order(IrAnalyze *ira, IrInstruction *value, AtomicOrder *out) {
     if (type_is_invalid(value->value.type))
         return false;

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -572,6 +572,10 @@ static constexpr IrInstructionId ir_instruction_id(IrInstructionArgType *) {
     return IrInstructionIdArgType;
 }
 
+static constexpr IrInstructionId ir_instruction_id(IrInstructionErrorReturnTrace *) {
+    return IrInstructionIdErrorReturnTrace;
+}
+
 template<typename T>
 static T *ir_create_instruction(IrBuilder *irb, Scope *scope, AstNode *source_node) {
     T *special_instruction = allocate<T>(1);
@@ -2305,6 +2309,12 @@ static IrInstruction *ir_build_arg_type(IrBuilder *irb, Scope *scope, AstNode *s
     return &instruction->base;
 }
 
+static IrInstruction *ir_build_error_return_trace(IrBuilder *irb, Scope *scope, AstNode *source_node) {
+    IrInstructionErrorReturnTrace *instruction = ir_build_instruction<IrInstructionErrorReturnTrace>(irb, scope, source_node);
+
+    return &instruction->base;
+}
+
 static void ir_count_defers(IrBuilder *irb, Scope *inner_scope, Scope *outer_scope, size_t *results) {
     results[ReturnKindUnconditional] = 0;
     results[ReturnKindError] = 0;
@@ -3730,6 +3740,10 @@ static IrInstruction *ir_gen_builtin_fn_call(IrBuilder *irb, Scope *scope, AstNo
                     return arg2_value;
 
                 return ir_build_export(irb, scope, node, arg0_value, arg1_value, arg2_value);
+            }
+        case BuiltinFnIdErrorReturnTrace:
+            {
+                return ir_build_error_return_trace(irb, scope, node);
             }
     }
     zig_unreachable();
@@ -9568,6 +9582,24 @@ static TypeTableEntry *ir_analyze_instruction_export(IrAnalyze *ira, IrInstructi
     return ira->codegen->builtin_types.entry_void;
 }
 
+static TypeTableEntry *ir_analyze_instruction_error_return_trace(IrAnalyze *ira,
+        IrInstructionErrorReturnTrace *instruction)
+{
+    FnTableEntry *fn_entry = exec_fn_entry(ira->new_irb.exec);
+    TypeTableEntry *ptr_to_stack_trace_type = get_ptr_to_stack_trace_type(ira->codegen);
+    TypeTableEntry *nullable_type = get_maybe_type(ira->codegen, ptr_to_stack_trace_type);
+    if (fn_entry == nullptr || !fn_entry->calls_errorable_function || !ira->codegen->have_err_ret_tracing) {
+        ConstExprValue *out_val = ir_build_const_from(ira, &instruction->base);
+        out_val->data.x_maybe = nullptr;
+        return nullable_type;
+    }
+
+    IrInstruction *new_instruction = ir_build_error_return_trace(&ira->new_irb, instruction->base.scope,
+            instruction->base.source_node);
+    ir_link_new_instruction(new_instruction, &instruction->base);
+    return nullable_type;
+}
+
 static bool ir_analyze_fn_call_inline_arg(IrAnalyze *ira, AstNode *fn_proto_node,
     IrInstruction *arg, Scope **exec_scope, size_t *next_proto_i)
 {
@@ -15324,6 +15356,8 @@ static TypeTableEntry *ir_analyze_instruction_nocast(IrAnalyze *ira, IrInstructi
             return ir_analyze_instruction_tag_type(ira, (IrInstructionTagType *)instruction);
         case IrInstructionIdExport:
             return ir_analyze_instruction_export(ira, (IrInstructionExport *)instruction);
+        case IrInstructionIdErrorReturnTrace:
+            return ir_analyze_instruction_error_return_trace(ira, (IrInstructionErrorReturnTrace *)instruction);
     }
     zig_unreachable();
 }
@@ -15507,6 +15541,7 @@ bool ir_has_side_effects(IrInstruction *instruction) {
         case IrInstructionIdOpaqueType:
         case IrInstructionIdArgType:
         case IrInstructionIdTagType:
+        case IrInstructionIdErrorReturnTrace:
             return false;
         case IrInstructionIdAsm:
             {

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -10043,8 +10043,20 @@ static TypeTableEntry *ir_analyze_fn_call(IrAnalyze *ira, IrInstructionCall *cal
         TypeTableEntry *return_type = impl_fn->type_entry->data.fn.fn_type_id.return_type;
         ir_add_alloca(ira, new_call_instruction, return_type);
 
+        if (return_type->id == TypeTableEntryIdPureError || return_type->id == TypeTableEntryIdErrorUnion) {
+            parent_fn_entry->calls_errorable_function = true;
+        }
+
         return ir_finish_anal(ira, return_type);
     }
+
+    FnTableEntry *parent_fn_entry = exec_fn_entry(ira->new_irb.exec);
+    assert(fn_type_id->return_type != nullptr);
+    assert(parent_fn_entry != nullptr);
+    if (fn_type_id->return_type->id == TypeTableEntryIdPureError || fn_type_id->return_type->id == TypeTableEntryIdErrorUnion) {
+        parent_fn_entry->calls_errorable_function = true;
+    }
+
 
     IrInstruction **casted_args = allocate<IrInstruction *>(call_param_count);
     size_t next_arg_index = 0;

--- a/src/ir_print.cpp
+++ b/src/ir_print.cpp
@@ -996,6 +996,10 @@ static void ir_print_export(IrPrint *irp, IrInstructionExport *instruction) {
     }
 }
 
+static void ir_print_error_return_trace(IrPrint *irp, IrInstructionErrorReturnTrace *instruction) {
+    fprintf(irp->f, "@errorReturnTrace()");
+}
+
 
 static void ir_print_instruction(IrPrint *irp, IrInstruction *instruction) {
     ir_print_prefix(irp, instruction);
@@ -1307,6 +1311,9 @@ static void ir_print_instruction(IrPrint *irp, IrInstruction *instruction) {
             break;
         case IrInstructionIdExport:
             ir_print_export(irp, (IrInstructionExport *)instruction);
+            break;
+        case IrInstructionIdErrorReturnTrace:
+            ir_print_error_return_trace(irp, (IrInstructionErrorReturnTrace *)instruction);
             break;
     }
     fprintf(irp->f, "\n");

--- a/std/build.zig
+++ b/std/build.zig
@@ -721,11 +721,9 @@ pub const Builder = struct {
         return error.FileNotFound;
     }
 
-    pub fn exec(self: &Builder, argv: []const []const u8) -> []u8 {
+    pub fn exec(self: &Builder, argv: []const []const u8) -> %[]u8 {
         const max_output_size = 100 * 1024;
-        const result = os.ChildProcess.exec(self.allocator, argv, null, null, max_output_size) catch |err| {
-            std.debug.panic("Unable to spawn {}: {}", argv[0], @errorName(err));
-        };
+        const result = try os.ChildProcess.exec(self.allocator, argv, null, null, max_output_size);
         switch (result.term) {
             os.ChildProcess.Term.Exited => |code| {
                 if (code != 0) {

--- a/std/build.zig
+++ b/std/build.zig
@@ -247,11 +247,11 @@ pub const Builder = struct {
         defer wanted_steps.deinit();
 
         if (step_names.len == 0) {
-            wanted_steps.append(&self.default_step) catch unreachable;
+            try wanted_steps.append(&self.default_step);
         } else {
             for (step_names) |step_name| {
                 const s = try self.getTopLevelStepByName(step_name);
-                wanted_steps.append(s) catch unreachable;
+                try wanted_steps.append(s);
             }
         }
 

--- a/std/debug/index.zig
+++ b/std/debug/index.zig
@@ -13,6 +13,10 @@ pub const FailingAllocator = @import("failing_allocator.zig").FailingAllocator;
 error MissingDebugInfo;
 error InvalidDebugInfo;
 error UnsupportedDebugInfo;
+error UnknownObjectFormat;
+error TodoSupportCoffDebugInfo;
+error TodoSupportMachoDebugInfo;
+error TodoSupportCOFFDebugInfo;
 
 
 /// Tries to write to stderr, unbuffered, and ignores any error returned.
@@ -40,13 +44,29 @@ fn getStderrStream() -> %&io.OutStream {
 /// Tries to print the current stack trace to stderr, unbuffered, and ignores any error returned.
 pub fn dumpCurrentStackTrace() {
     const stderr = getStderrStream() catch return;
-    writeCurrentStackTrace(stderr, global_allocator, stderr_file.isTty(), 1) catch return;
+    const debug_info = openSelfDebugInfo(global_allocator) catch |err| {
+        stderr.print("Unable to open debug info: {}\n", @errorName(err)) catch return;
+        return;
+    };
+    defer debug_info.close();
+    writeCurrentStackTrace(stderr, global_allocator, debug_info, stderr_file.isTty(), 1) catch |err| {
+        stderr.print("Unable to dump stack trace: {}\n", @errorName(err)) catch return;
+        return;
+    };
 }
 
 /// Tries to print a stack trace to stderr, unbuffered, and ignores any error returned.
 pub fn dumpStackTrace(stack_trace: &builtin.StackTrace) {
     const stderr = getStderrStream() catch return;
-    writeStackTrace(stack_trace, stderr, global_allocator, stderr_file.isTty()) catch return;
+    const debug_info = openSelfDebugInfo(global_allocator) catch |err| {
+        stderr.print("Unable to open debug info: {}\n", @errorName(err)) catch return;
+        return;
+    };
+    defer debug_info.close();
+    writeStackTrace(stack_trace, stderr, global_allocator, debug_info, stderr_file.isTty()) catch |err| {
+        stderr.print("Unable to dump stack trace: {}\n", @errorName(err)) catch return;
+        return;
+    };
 }
 
 /// This function invokes undefined behavior when `ok` is `false`.
@@ -94,7 +114,7 @@ pub fn panic(comptime format: []const u8, args: ...) -> noreturn {
 
     const stderr = getStderrStream() catch os.abort();
     stderr.print(format ++ "\n", args) catch os.abort();
-    writeCurrentStackTrace(stderr, global_allocator, stderr_file.isTty(), 1) catch os.abort();
+    dumpCurrentStackTrace();
 
     os.abort();
 }
@@ -107,108 +127,88 @@ const RESET = "\x1b[0m";
 error PathNotFound;
 error InvalidDebugInfo;
 
-pub fn writeStackTrace(st_addrs: &builtin.StackTrace, out_stream: &io.OutStream, allocator: &mem.Allocator, tty_color: bool) -> %void {
-    switch (builtin.object_format) {
-        builtin.ObjectFormat.elf => {
-            var stack_trace = ElfStackTrace {
-                .self_exe_file = undefined,
-                .elf = undefined,
-                .debug_info = undefined,
-                .debug_abbrev = undefined,
-                .debug_str = undefined,
-                .debug_line = undefined,
-                .debug_ranges = null,
-                .abbrev_table_list = ArrayList(AbbrevTableHeader).init(allocator),
-                .compile_unit_list = ArrayList(CompileUnit).init(allocator),
-            };
-            const st = &stack_trace;
-            st.self_exe_file = try os.openSelfExe();
-            defer st.self_exe_file.close();
+pub fn writeStackTrace(stack_trace: &builtin.StackTrace, out_stream: &io.OutStream, allocator: &mem.Allocator,
+    debug_info: &ElfStackTrace, tty_color: bool) -> %void
+{
+    var frame_index: usize = undefined;
+    var frames_left: usize = undefined;
+    if (stack_trace.index < stack_trace.instruction_addresses.len) {
+        frame_index = 0;
+        frames_left = stack_trace.index;
+    } else {
+        frame_index = (stack_trace.index + 1) % stack_trace.instruction_addresses.len;
+        frames_left = stack_trace.instruction_addresses.len;
+    }
 
-            try st.elf.openFile(allocator, &st.self_exe_file);
-            defer st.elf.close();
-
-            st.debug_info = (try st.elf.findSection(".debug_info")) ?? return error.MissingDebugInfo;
-            st.debug_abbrev = (try st.elf.findSection(".debug_abbrev")) ?? return error.MissingDebugInfo;
-            st.debug_str = (try st.elf.findSection(".debug_str")) ?? return error.MissingDebugInfo;
-            st.debug_line = (try st.elf.findSection(".debug_line")) ?? return error.MissingDebugInfo;
-            st.debug_ranges = (try st.elf.findSection(".debug_ranges"));
-            try scanAllCompileUnits(st);
-
-            var ignored_count: usize = 0;
-
-            var frame_index: usize = undefined;
-            var frames_left: usize = undefined;
-            if (st_addrs.index < st_addrs.instruction_addresses.len) {
-                frame_index = 0;
-                frames_left = st_addrs.index;
-            } else {
-                frame_index = (st_addrs.index + 1) % st_addrs.instruction_addresses.len;
-                frames_left = st_addrs.instruction_addresses.len;
-            }
-
-            while (frames_left != 0) : ({frames_left -= 1; frame_index = (frame_index + 1) % st_addrs.instruction_addresses.len;}) {
-                const return_address = st_addrs.instruction_addresses[frame_index];
-
-                // TODO we really should be able to convert @sizeOf(usize) * 2 to a string literal
-                // at compile time. I'll call it issue #313
-                const ptr_hex = if (@sizeOf(usize) == 4) "0x{x8}" else "0x{x16}";
-
-                const compile_unit = findCompileUnit(st, return_address) catch {
-                    try out_stream.print("???:?:?: " ++ DIM ++ ptr_hex ++ " in ??? (???)" ++ RESET ++ "\n    ???\n\n",
-                        return_address);
-                    continue;
-                };
-                const compile_unit_name = try compile_unit.die.getAttrString(st, DW.AT_name);
-                if (getLineNumberInfo(st, compile_unit, usize(return_address) - 1)) |line_info| {
-                    defer line_info.deinit();
-                    try out_stream.print(WHITE ++ "{}:{}:{}" ++ RESET ++ ": " ++
-                        DIM ++ ptr_hex ++ " in ??? ({})" ++ RESET ++ "\n",
-                        line_info.file_name, line_info.line, line_info.column,
-                        return_address, compile_unit_name);
-                    if (printLineFromFile(st.allocator(), out_stream, line_info)) {
-                        if (line_info.column == 0) {
-                            try out_stream.write("\n");
-                        } else {
-                            {var col_i: usize = 1; while (col_i < line_info.column) : (col_i += 1) {
-                                try out_stream.writeByte(' ');
-                            }}
-                            try out_stream.write(GREEN ++ "^" ++ RESET ++ "\n");
-                        }
-                    } else |err| switch (err) {
-                        error.EndOfFile, error.PathNotFound => {},
-                        else => return err,
-                    }
-                } else |err| switch (err) {
-                    error.MissingDebugInfo, error.InvalidDebugInfo => {
-                        try out_stream.print(ptr_hex ++ " in ??? ({})\n",
-                            return_address, compile_unit_name);
-                    },
-                    else => return err,
-                }
-            }
-        },
-        builtin.ObjectFormat.coff => {
-            try out_stream.write("(stack trace unavailable for COFF object format)\n");
-        },
-        builtin.ObjectFormat.macho => {
-            try out_stream.write("(stack trace unavailable for Mach-O object format)\n");
-        },
-        builtin.ObjectFormat.wasm => {
-            try out_stream.write("(stack trace unavailable for WASM object format)\n");
-        },
-        builtin.ObjectFormat.unknown => {
-            try out_stream.write("(stack trace unavailable for unknown object format)\n");
-        },
+    while (frames_left != 0) : ({
+        frames_left -= 1;
+        frame_index = (frame_index + 1) % stack_trace.instruction_addresses.len;
+    }) {
+        const return_address = stack_trace.instruction_addresses[frame_index];
+        try printSourceAtAddress(debug_info, out_stream, return_address);
     }
 }
 
-pub fn writeCurrentStackTrace(out_stream: &io.OutStream, allocator: &mem.Allocator, tty_color: bool,
-    ignore_frame_count: usize) -> %void
+pub fn writeCurrentStackTrace(out_stream: &io.OutStream, allocator: &mem.Allocator,
+    debug_info: &ElfStackTrace, tty_color: bool, ignore_frame_count: usize) -> %void
 {
+    var ignored_count: usize = 0;
+
+    var fp = @ptrToInt(@frameAddress());
+    while (fp != 0) : (fp = *@intToPtr(&const usize, fp)) {
+        if (ignored_count < ignore_frame_count) {
+            ignored_count += 1;
+            continue;
+        }
+
+        const return_address = *@intToPtr(&const usize, fp + @sizeOf(usize));
+        try printSourceAtAddress(debug_info, out_stream, return_address);
+    }
+}
+
+fn printSourceAtAddress(debug_info: &ElfStackTrace, out_stream: &io.OutStream, address: usize) -> %void {
+    // TODO we really should be able to convert @sizeOf(usize) * 2 to a string literal
+    // at compile time. I'll call it issue #313
+    const ptr_hex = if (@sizeOf(usize) == 4) "0x{x8}" else "0x{x16}";
+
+    const compile_unit = findCompileUnit(debug_info, address) catch {
+        try out_stream.print("???:?:?: " ++ DIM ++ ptr_hex ++ " in ??? (???)" ++ RESET ++ "\n    ???\n\n",
+            address);
+        return;
+    };
+    const compile_unit_name = try compile_unit.die.getAttrString(debug_info, DW.AT_name);
+    if (getLineNumberInfo(debug_info, compile_unit, usize(address) - 1)) |line_info| {
+        defer line_info.deinit();
+        try out_stream.print(WHITE ++ "{}:{}:{}" ++ RESET ++ ": " ++
+            DIM ++ ptr_hex ++ " in ??? ({})" ++ RESET ++ "\n",
+            line_info.file_name, line_info.line, line_info.column,
+            address, compile_unit_name);
+        if (printLineFromFile(debug_info.allocator(), out_stream, line_info)) {
+            if (line_info.column == 0) {
+                try out_stream.write("\n");
+            } else {
+                {var col_i: usize = 1; while (col_i < line_info.column) : (col_i += 1) {
+                    try out_stream.writeByte(' ');
+                }}
+                try out_stream.write(GREEN ++ "^" ++ RESET ++ "\n");
+            }
+        } else |err| switch (err) {
+            error.EndOfFile, error.PathNotFound => {},
+            else => return err,
+        }
+    } else |err| switch (err) {
+        error.MissingDebugInfo, error.InvalidDebugInfo => {
+            try out_stream.print(ptr_hex ++ " in ??? ({})\n", address, compile_unit_name);
+        },
+        else => return err,
+    }
+}
+
+pub fn openSelfDebugInfo(allocator: &mem.Allocator) -> %&ElfStackTrace {
     switch (builtin.object_format) {
         builtin.ObjectFormat.elf => {
-            var stack_trace = ElfStackTrace {
+            const st = try allocator.create(ElfStackTrace);
+            *st = ElfStackTrace {
                 .self_exe_file = undefined,
                 .elf = undefined,
                 .debug_info = undefined,
@@ -219,12 +219,11 @@ pub fn writeCurrentStackTrace(out_stream: &io.OutStream, allocator: &mem.Allocat
                 .abbrev_table_list = ArrayList(AbbrevTableHeader).init(allocator),
                 .compile_unit_list = ArrayList(CompileUnit).init(allocator),
             };
-            const st = &stack_trace;
             st.self_exe_file = try os.openSelfExe();
-            defer st.self_exe_file.close();
+            %defer st.self_exe_file.close();
 
             try st.elf.openFile(allocator, &st.self_exe_file);
-            defer st.elf.close();
+            %defer st.elf.close();
 
             st.debug_info = (try st.elf.findSection(".debug_info")) ?? return error.MissingDebugInfo;
             st.debug_abbrev = (try st.elf.findSection(".debug_abbrev")) ?? return error.MissingDebugInfo;
@@ -232,67 +231,19 @@ pub fn writeCurrentStackTrace(out_stream: &io.OutStream, allocator: &mem.Allocat
             st.debug_line = (try st.elf.findSection(".debug_line")) ?? return error.MissingDebugInfo;
             st.debug_ranges = (try st.elf.findSection(".debug_ranges"));
             try scanAllCompileUnits(st);
-
-            var ignored_count: usize = 0;
-
-            var fp = @ptrToInt(@frameAddress());
-            while (fp != 0) : (fp = *@intToPtr(&const usize, fp)) {
-                if (ignored_count < ignore_frame_count) {
-                    ignored_count += 1;
-                    continue;
-                }
-
-                const return_address = *@intToPtr(&const usize, fp + @sizeOf(usize));
-
-                // TODO we really should be able to convert @sizeOf(usize) * 2 to a string literal
-                // at compile time. I'll call it issue #313
-                const ptr_hex = if (@sizeOf(usize) == 4) "0x{x8}" else "0x{x16}";
-
-                const compile_unit = findCompileUnit(st, return_address) catch {
-                    try out_stream.print("???:?:?: " ++ DIM ++ ptr_hex ++ " in ??? (???)" ++ RESET ++ "\n    ???\n\n",
-                        return_address);
-                    continue;
-                };
-                const compile_unit_name = try compile_unit.die.getAttrString(st, DW.AT_name);
-                if (getLineNumberInfo(st, compile_unit, usize(return_address) - 1)) |line_info| {
-                    defer line_info.deinit();
-                    try out_stream.print(WHITE ++ "{}:{}:{}" ++ RESET ++ ": " ++
-                        DIM ++ ptr_hex ++ " in ??? ({})" ++ RESET ++ "\n",
-                        line_info.file_name, line_info.line, line_info.column,
-                        return_address, compile_unit_name);
-                    if (printLineFromFile(st.allocator(), out_stream, line_info)) {
-                        if (line_info.column == 0) {
-                            try out_stream.write("\n");
-                        } else {
-                            {var col_i: usize = 1; while (col_i < line_info.column) : (col_i += 1) {
-                                try out_stream.writeByte(' ');
-                            }}
-                            try out_stream.write(GREEN ++ "^" ++ RESET ++ "\n");
-                        }
-                    } else |err| switch (err) {
-                        error.EndOfFile, error.PathNotFound => {},
-                        else => return err,
-                    }
-                } else |err| switch (err) {
-                    error.MissingDebugInfo, error.InvalidDebugInfo => {
-                        try out_stream.print(ptr_hex ++ " in ??? ({})\n",
-                            return_address, compile_unit_name);
-                    },
-                    else => return err,
-                }
-            }
+            return st;
         },
         builtin.ObjectFormat.coff => {
-            try out_stream.write("(stack trace unavailable for COFF object format)\n");
+            return error.TodoSupportCoffDebugInfo;
         },
         builtin.ObjectFormat.macho => {
-            try out_stream.write("(stack trace unavailable for Mach-O object format)\n");
+            return error.TodoSupportMachoDebugInfo;
         },
         builtin.ObjectFormat.wasm => {
-            try out_stream.write("(stack trace unavailable for WASM object format)\n");
+            return error.TodoSupportCOFFDebugInfo;
         },
         builtin.ObjectFormat.unknown => {
-            try out_stream.write("(stack trace unavailable for unknown object format)\n");
+            return error.UnknownObjectFormat;
         },
     }
 }
@@ -330,7 +281,7 @@ fn printLineFromFile(allocator: &mem.Allocator, out_stream: &io.OutStream, line_
     }
 }
 
-const ElfStackTrace = struct {
+pub const ElfStackTrace = struct {
     self_exe_file: io.File,
     elf: elf.Elf,
     debug_info: &elf.SectionHeader,
@@ -349,6 +300,11 @@ const ElfStackTrace = struct {
         var in_file_stream = io.FileInStream.init(&self.self_exe_file);
         const in_stream = &in_file_stream.stream;
         return readStringRaw(self.allocator(), in_stream);
+    }
+
+    pub fn close(self: &ElfStackTrace) {
+        self.self_exe_file.close();
+        self.elf.close();
     }
 };
 

--- a/std/io.zig
+++ b/std/io.zig
@@ -224,7 +224,7 @@ pub const File = struct {
                     };
                 }
             },
-            else => @compileError("unsupported OS"),
+            else => @compileError("unsupported OS: " ++ @tagName(builtin.os)),
         }
     }
 

--- a/std/os/index.zig
+++ b/std/os/index.zig
@@ -148,7 +148,7 @@ pub coldcc fn abort() -> noreturn {
 }
 
 /// Exits the program cleanly with the specified status code.
-pub coldcc fn exit(status: i32) -> noreturn {
+pub coldcc fn exit(status: u8) -> noreturn {
     if (builtin.link_libc) {
         c.exit(status);
     }
@@ -157,14 +157,7 @@ pub coldcc fn exit(status: i32) -> noreturn {
             posix.exit(status);
         },
         Os.windows => {
-            // Map a possibly negative status code to a non-negative status for the systems default
-            // integer width.
-            const p_status = if (@sizeOf(c_uint) < @sizeOf(u32))
-                @truncate(c_uint, @bitCast(u32, status))
-            else
-                c_uint(@bitCast(u32, status));
-
-            windows.ExitProcess(p_status);
+            windows.ExitProcess(status);
         },
         else => @compileError("Unsupported OS"),
     }

--- a/std/special/bootstrap.zig
+++ b/std/special/bootstrap.zig
@@ -21,8 +21,7 @@ comptime {
 }
 
 extern fn zenMain() -> noreturn {
-    root.main() catch std.os.posix.exit(1);
-    std.os.posix.exit(0);
+    std.os.posix.exit(callMain());
 }
 
 nakedcc fn _start() -> noreturn {
@@ -43,29 +42,55 @@ nakedcc fn _start() -> noreturn {
 extern fn WinMainCRTStartup() -> noreturn {
     @setAlignStack(16);
 
-    root.main() catch std.os.windows.ExitProcess(1);
-    std.os.windows.ExitProcess(0);
+    std.os.windows.ExitProcess(callMain());
 }
 
 fn posixCallMainAndExit() -> noreturn {
     const argc = *argc_ptr;
     const argv = @ptrCast(&&u8, &argc_ptr[1]);
     const envp = @ptrCast(&?&u8, &argv[argc + 1]);
-    callMain(argc, argv, envp) catch std.os.posix.exit(1);
-    std.os.posix.exit(0);
+    std.os.posix.exit(callMainWithArgs(argc, argv, envp));
 }
 
-fn callMain(argc: usize, argv: &&u8, envp: &?&u8) -> %void {
+fn callMainWithArgs(argc: usize, argv: &&u8, envp: &?&u8) -> u8 {
     std.os.ArgIteratorPosix.raw = argv[0..argc];
 
     var env_count: usize = 0;
     while (envp[env_count] != null) : (env_count += 1) {}
     std.os.posix_environ_raw = @ptrCast(&&u8, envp)[0..env_count];
 
-    return root.main();
+    return callMain();
 }
 
 extern fn main(c_argc: i32, c_argv: &&u8, c_envp: &?&u8) -> i32 {
-    callMain(usize(c_argc), c_argv, c_envp) catch return 1;
-    return 0;
+    return callMainWithArgs(usize(c_argc), c_argv, c_envp);
+}
+
+fn callMain() -> u8 {
+    switch (@typeId(@typeOf(root.main).ReturnType)) {
+        builtin.TypeId.NoReturn => {
+            root.main();
+        },
+        builtin.TypeId.Void => {
+            root.main();
+            return 0;
+        },
+        builtin.TypeId.Int => {
+            if (@typeOf(root.main).ReturnType.bit_count != 8) {
+                @compileError("expected return type of main to be 'u8', 'noreturn', 'void', or '%void'");
+            }
+            return root.main();
+        },
+        builtin.TypeId.ErrorUnion => {
+            root.main() catch |err| {
+                std.debug.warn("error: {}\n", @errorName(err));
+                if (@errorReturnTrace()) |trace| {
+                    std.debug.dumpStackTrace(trace);
+                }
+                return 1;
+            };
+            return 0;
+        },
+        else => @compileError("expected return type of main to be 'u8', 'noreturn', 'void', or '%void'"),
+    }
 }

--- a/std/special/build_runner.zig
+++ b/std/special/build_runner.zig
@@ -112,7 +112,7 @@ pub fn main() -> %void {
     }
 
     builder.setInstallPrefix(prefix);
-    root.build(&builder);
+    root.build(&builder) catch unreachable;
 
     if (builder.validateUserInputDidItFail())
         return usageAndErr(&builder, true, try stderr_stream);
@@ -129,7 +129,7 @@ fn usage(builder: &Builder, already_ran_build: bool, out_stream: &io.OutStream) 
     // run the build script to collect the options
     if (!already_ran_build) {
         builder.setInstallPrefix(null);
-        root.build(builder);
+        root.build(builder) catch unreachable;
     }
 
     // This usage text has to be synchronized with src/main.cpp

--- a/std/special/build_runner.zig
+++ b/std/special/build_runner.zig
@@ -14,7 +14,7 @@ pub fn main() -> %void {
     var arg_it = os.args();
 
     // TODO use a more general purpose allocator here
-    var inc_allocator = std.heap.IncrementingAllocator.init(40 * 1024 * 1024) catch unreachable;
+    var inc_allocator = try std.heap.IncrementingAllocator.init(40 * 1024 * 1024);
     defer inc_allocator.deinit();
 
     const allocator = &inc_allocator.allocator;
@@ -107,12 +107,12 @@ pub fn main() -> %void {
                 return usageAndErr(&builder, false, try stderr_stream);
             }
         } else {
-            targets.append(arg) catch unreachable;
+            try targets.append(arg);
         }
     }
 
     builder.setInstallPrefix(prefix);
-    root.build(&builder) catch unreachable;
+    try root.build(&builder);
 
     if (builder.validateUserInputDidItFail())
         return usageAndErr(&builder, true, try stderr_stream);
@@ -129,7 +129,7 @@ fn usage(builder: &Builder, already_ran_build: bool, out_stream: &io.OutStream) 
     // run the build script to collect the options
     if (!already_ran_build) {
         builder.setInstallPrefix(null);
-        root.build(builder) catch unreachable;
+        try root.build(builder);
     }
 
     // This usage text has to be synchronized with src/main.cpp

--- a/std/special/builtin.zig
+++ b/std/special/builtin.zig
@@ -5,7 +5,7 @@ const builtin = @import("builtin");
 
 // Avoid dragging in the debug safety mechanisms into this .o file,
 // unless we're trying to test this file.
-pub coldcc fn panic(msg: []const u8) -> noreturn {
+pub coldcc fn panic(msg: []const u8, error_return_trace: ?&builtin.StackTrace) -> noreturn {
     if (builtin.is_test) {
         @import("std").debug.panic("{}", msg);
     } else {

--- a/std/special/compiler_rt/index.zig
+++ b/std/special/compiler_rt/index.zig
@@ -74,7 +74,7 @@ const __udivmoddi4 = @import("udivmoddi4.zig").__udivmoddi4;
 
 // Avoid dragging in the debug safety mechanisms into this .o file,
 // unless we're trying to test this file.
-pub coldcc fn panic(msg: []const u8) -> noreturn {
+pub coldcc fn panic(msg: []const u8, error_return_trace: ?&builtin.StackTrace) -> noreturn {
     if (is_test) {
         @import("std").debug.panic("{}", msg);
     } else {

--- a/std/special/panic.zig
+++ b/std/special/panic.zig
@@ -4,14 +4,20 @@
 // have to be added in the compiler.
 
 const builtin = @import("builtin");
+const std = @import("std");
 
-pub coldcc fn panic(msg: []const u8) -> noreturn {
+pub coldcc fn panic(msg: []const u8, error_return_trace: ?&builtin.StackTrace) -> noreturn {
     switch (builtin.os) {
         // TODO: fix panic in zen.
         builtin.Os.freestanding, builtin.Os.zen => {
             while (true) {}
         },
         else => {
+            if (error_return_trace) |trace| {
+                std.debug.warn("{}\n", msg);
+                std.debug.dumpStackTrace(trace);
+                @import("std").debug.panic("");
+            }
             @import("std").debug.panic("{}", msg);
         },
     }

--- a/std/special/panic.zig
+++ b/std/special/panic.zig
@@ -13,10 +13,12 @@ pub coldcc fn panic(msg: []const u8, error_return_trace: ?&builtin.StackTrace) -
             while (true) {}
         },
         else => {
-            if (error_return_trace) |trace| {
-                std.debug.warn("{}\n", msg);
-                std.debug.dumpStackTrace(trace);
-                @import("std").debug.panic("");
+            if (builtin.have_error_return_tracing) {
+                if (error_return_trace) |trace| {
+                    std.debug.warn("{}\n", msg);
+                    std.debug.dumpStackTrace(trace);
+                    @import("std").debug.panic("");
+                }
             }
             @import("std").debug.panic("{}", msg);
         },

--- a/std/special/test_runner.zig
+++ b/std/special/test_runner.zig
@@ -8,14 +8,7 @@ pub fn main() -> %void {
     for (test_fn_list) |test_fn, i| {
         warn("Test {}/{} {}...", i + 1, test_fn_list.len, test_fn.name);
 
-        if (builtin.is_test) {
-            test_fn.func() catch unreachable;
-        } else {
-            test_fn.func() catch |err| {
-                warn("{}\n", err);
-                return err;
-            };
-        }
+        try test_fn.func();
 
         warn("OK\n");
     }

--- a/std/special/test_runner.zig
+++ b/std/special/test_runner.zig
@@ -8,10 +8,14 @@ pub fn main() -> %void {
     for (test_fn_list) |test_fn, i| {
         warn("Test {}/{} {}...", i + 1, test_fn_list.len, test_fn.name);
 
-        test_fn.func() catch |err| {
-            warn("{}\n", err);
-            return err;
-        };
+        if (builtin.is_test) {
+            test_fn.func() catch unreachable;
+        } else {
+            test_fn.func() catch |err| {
+                warn("{}\n", err);
+                return err;
+            };
+        }
 
         warn("OK\n");
     }

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -1,6 +1,15 @@
 const tests = @import("tests.zig");
 
 pub fn addCases(cases: &tests.CompileErrorContext) {
+    cases.add("wrong return type for main",
+        \\pub fn main() -> f32 { }
+    , "error: expected return type of main to be 'u8', 'noreturn', 'void', or '%void'");
+
+    cases.add("double ?? on main return value",
+        \\pub fn main() -> ??void {
+        \\}
+    , "error: expected return type of main to be 'u8', 'noreturn', 'void', or '%void'");
+
     cases.add("bad identifier in function with struct defined inside function which references local const",
         \\export fn entry() {
         \\    const BlockKind = u32;
@@ -1058,15 +1067,6 @@ pub fn addCases(cases: &tests.CompileErrorContext) {
         \\fn something() -> %void { }
     ,
             ".tmp_source.zig:2:5: error: expected type 'void', found 'error'");
-
-    cases.add("wrong return type for main",
-        \\pub fn main() { }
-    , ".tmp_source.zig:1:15: error: expected return type of main to be '%void', instead is 'void'");
-
-    cases.add("double ?? on main return value",
-        \\pub fn main() -> ??void {
-        \\}
-    , ".tmp_source.zig:1:18: error: expected return type of main to be '%void', instead is '??void'");
 
     cases.add("invalid pointer for var type",
         \\extern fn ext() -> usize;

--- a/test/debug_safety.zig
+++ b/test/debug_safety.zig
@@ -2,7 +2,7 @@ const tests = @import("tests.zig");
 
 pub fn addCases(cases: &tests.CompareOutputContext) {
     cases.addDebugSafety("calling panic",
-        \\pub fn panic(message: []const u8) -> noreturn {
+        \\pub fn panic(message: []const u8, stack_trace: ?&@import("builtin").StackTrace) -> noreturn {
         \\    @import("std").os.exit(126);
         \\}
         \\pub fn main() -> %void {
@@ -11,7 +11,7 @@ pub fn addCases(cases: &tests.CompareOutputContext) {
     );
 
     cases.addDebugSafety("out of bounds slice access",
-        \\pub fn panic(message: []const u8) -> noreturn {
+        \\pub fn panic(message: []const u8, stack_trace: ?&@import("builtin").StackTrace) -> noreturn {
         \\    @import("std").os.exit(126);
         \\}
         \\pub fn main() -> %void {
@@ -25,7 +25,7 @@ pub fn addCases(cases: &tests.CompareOutputContext) {
     );
 
     cases.addDebugSafety("integer addition overflow",
-        \\pub fn panic(message: []const u8) -> noreturn {
+        \\pub fn panic(message: []const u8, stack_trace: ?&@import("builtin").StackTrace) -> noreturn {
         \\    @import("std").os.exit(126);
         \\}
         \\error Whatever;
@@ -39,7 +39,7 @@ pub fn addCases(cases: &tests.CompareOutputContext) {
     );
 
     cases.addDebugSafety("integer subtraction overflow",
-        \\pub fn panic(message: []const u8) -> noreturn {
+        \\pub fn panic(message: []const u8, stack_trace: ?&@import("builtin").StackTrace) -> noreturn {
         \\    @import("std").os.exit(126);
         \\}
         \\error Whatever;
@@ -53,7 +53,7 @@ pub fn addCases(cases: &tests.CompareOutputContext) {
     );
 
     cases.addDebugSafety("integer multiplication overflow",
-        \\pub fn panic(message: []const u8) -> noreturn {
+        \\pub fn panic(message: []const u8, stack_trace: ?&@import("builtin").StackTrace) -> noreturn {
         \\    @import("std").os.exit(126);
         \\}
         \\error Whatever;
@@ -67,7 +67,7 @@ pub fn addCases(cases: &tests.CompareOutputContext) {
     );
 
     cases.addDebugSafety("integer negation overflow",
-        \\pub fn panic(message: []const u8) -> noreturn {
+        \\pub fn panic(message: []const u8, stack_trace: ?&@import("builtin").StackTrace) -> noreturn {
         \\    @import("std").os.exit(126);
         \\}
         \\error Whatever;
@@ -81,7 +81,7 @@ pub fn addCases(cases: &tests.CompareOutputContext) {
     );
 
     cases.addDebugSafety("signed integer division overflow",
-        \\pub fn panic(message: []const u8) -> noreturn {
+        \\pub fn panic(message: []const u8, stack_trace: ?&@import("builtin").StackTrace) -> noreturn {
         \\    @import("std").os.exit(126);
         \\}
         \\error Whatever;
@@ -95,7 +95,7 @@ pub fn addCases(cases: &tests.CompareOutputContext) {
     );
 
     cases.addDebugSafety("signed shift left overflow",
-        \\pub fn panic(message: []const u8) -> noreturn {
+        \\pub fn panic(message: []const u8, stack_trace: ?&@import("builtin").StackTrace) -> noreturn {
         \\    @import("std").os.exit(126);
         \\}
         \\error Whatever;
@@ -109,7 +109,7 @@ pub fn addCases(cases: &tests.CompareOutputContext) {
     );
 
     cases.addDebugSafety("unsigned shift left overflow",
-        \\pub fn panic(message: []const u8) -> noreturn {
+        \\pub fn panic(message: []const u8, stack_trace: ?&@import("builtin").StackTrace) -> noreturn {
         \\    @import("std").os.exit(126);
         \\}
         \\error Whatever;
@@ -123,7 +123,7 @@ pub fn addCases(cases: &tests.CompareOutputContext) {
     );
 
     cases.addDebugSafety("signed shift right overflow",
-        \\pub fn panic(message: []const u8) -> noreturn {
+        \\pub fn panic(message: []const u8, stack_trace: ?&@import("builtin").StackTrace) -> noreturn {
         \\    @import("std").os.exit(126);
         \\}
         \\error Whatever;
@@ -137,7 +137,7 @@ pub fn addCases(cases: &tests.CompareOutputContext) {
     );
 
     cases.addDebugSafety("unsigned shift right overflow",
-        \\pub fn panic(message: []const u8) -> noreturn {
+        \\pub fn panic(message: []const u8, stack_trace: ?&@import("builtin").StackTrace) -> noreturn {
         \\    @import("std").os.exit(126);
         \\}
         \\error Whatever;
@@ -151,7 +151,7 @@ pub fn addCases(cases: &tests.CompareOutputContext) {
     );
 
     cases.addDebugSafety("integer division by zero",
-        \\pub fn panic(message: []const u8) -> noreturn {
+        \\pub fn panic(message: []const u8, stack_trace: ?&@import("builtin").StackTrace) -> noreturn {
         \\    @import("std").os.exit(126);
         \\}
         \\error Whatever;
@@ -164,7 +164,7 @@ pub fn addCases(cases: &tests.CompareOutputContext) {
     );
 
     cases.addDebugSafety("exact division failure",
-        \\pub fn panic(message: []const u8) -> noreturn {
+        \\pub fn panic(message: []const u8, stack_trace: ?&@import("builtin").StackTrace) -> noreturn {
         \\    @import("std").os.exit(126);
         \\}
         \\error Whatever;
@@ -178,7 +178,7 @@ pub fn addCases(cases: &tests.CompareOutputContext) {
     );
 
     cases.addDebugSafety("cast []u8 to bigger slice of wrong size",
-        \\pub fn panic(message: []const u8) -> noreturn {
+        \\pub fn panic(message: []const u8, stack_trace: ?&@import("builtin").StackTrace) -> noreturn {
         \\    @import("std").os.exit(126);
         \\}
         \\error Whatever;
@@ -192,7 +192,7 @@ pub fn addCases(cases: &tests.CompareOutputContext) {
     );
 
     cases.addDebugSafety("value does not fit in shortening cast",
-        \\pub fn panic(message: []const u8) -> noreturn {
+        \\pub fn panic(message: []const u8, stack_trace: ?&@import("builtin").StackTrace) -> noreturn {
         \\    @import("std").os.exit(126);
         \\}
         \\error Whatever;
@@ -206,7 +206,7 @@ pub fn addCases(cases: &tests.CompareOutputContext) {
     );
 
     cases.addDebugSafety("signed integer not fitting in cast to unsigned integer",
-        \\pub fn panic(message: []const u8) -> noreturn {
+        \\pub fn panic(message: []const u8, stack_trace: ?&@import("builtin").StackTrace) -> noreturn {
         \\    @import("std").os.exit(126);
         \\}
         \\error Whatever;
@@ -220,7 +220,7 @@ pub fn addCases(cases: &tests.CompareOutputContext) {
     );
 
     cases.addDebugSafety("unwrap error",
-        \\pub fn panic(message: []const u8) -> noreturn {
+        \\pub fn panic(message: []const u8, stack_trace: ?&@import("builtin").StackTrace) -> noreturn {
         \\    if (@import("std").mem.eql(u8, message, "attempt to unwrap error: Whatever")) {
         \\        @import("std").os.exit(126); // good
         \\    }
@@ -236,7 +236,7 @@ pub fn addCases(cases: &tests.CompareOutputContext) {
     );
 
     cases.addDebugSafety("cast integer to error and no code matches",
-        \\pub fn panic(message: []const u8) -> noreturn {
+        \\pub fn panic(message: []const u8, stack_trace: ?&@import("builtin").StackTrace) -> noreturn {
         \\    @import("std").os.exit(126);
         \\}
         \\pub fn main() -> %void {
@@ -248,7 +248,7 @@ pub fn addCases(cases: &tests.CompareOutputContext) {
     );
 
     cases.addDebugSafety("@alignCast misaligned",
-        \\pub fn panic(message: []const u8) -> noreturn {
+        \\pub fn panic(message: []const u8, stack_trace: ?&@import("builtin").StackTrace) -> noreturn {
         \\    @import("std").os.exit(126);
         \\}
         \\error Wrong;
@@ -265,7 +265,7 @@ pub fn addCases(cases: &tests.CompareOutputContext) {
     );
 
     cases.addDebugSafety("bad union field access",
-        \\pub fn panic(message: []const u8) -> noreturn {
+        \\pub fn panic(message: []const u8, stack_trace: ?&@import("builtin").StackTrace) -> noreturn {
         \\    @import("std").os.exit(126);
         \\}
         \\

--- a/test/standalone/issue_339/build.zig
+++ b/test/standalone/issue_339/build.zig
@@ -1,6 +1,6 @@
 const Builder = @import("std").build.Builder;
 
-pub fn build(b: &Builder) {
+pub fn build(b: &Builder) -> %void {
     const obj = b.addObject("test", "test.zig");
 
     const test_step = b.step("test", "Test the program");

--- a/test/standalone/issue_339/test.zig
+++ b/test/standalone/issue_339/test.zig
@@ -1,4 +1,5 @@
-pub fn panic(msg: []const u8) -> noreturn { @breakpoint(); while (true) {} }
+const StackTrace = @import("builtin").StackTrace;
+pub fn panic(msg: []const u8, stack_trace: ?&StackTrace) -> noreturn { @breakpoint(); while (true) {} }
 
 fn bar() -> %void {}
 

--- a/test/standalone/pkg_import/build.zig
+++ b/test/standalone/pkg_import/build.zig
@@ -1,6 +1,6 @@
 const Builder = @import("std").build.Builder;
 
-pub fn build(b: &Builder) {
+pub fn build(b: &Builder) -> %void {
     const exe = b.addExecutable("test", "test.zig");
     exe.addPackagePath("my_pkg", "pkg.zig");
 

--- a/test/standalone/use_alias/build.zig
+++ b/test/standalone/use_alias/build.zig
@@ -1,6 +1,6 @@
 const Builder = @import("std").build.Builder;
 
-pub fn build(b: &Builder) {
+pub fn build(b: &Builder) -> %void {
     b.addCIncludePath(".");
 
     const main = b.addTest("main.zig");

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -50,6 +50,7 @@ const test_targets = []TestTarget {
 };
 
 error TestFailed;
+error CompilationIncorrectlySucceeded;
 
 const max_stdout_size = 1 * 1024 * 1024; // 1 MB
 
@@ -607,8 +608,7 @@ pub const CompileErrorContext = struct {
             switch (term) {
                 Term.Exited => |code| {
                     if (code == 0) {
-                        warn("Compilation incorrectly succeeded\n");
-                        return error.TestFailed;
+                        return error.CompilationIncorrectlySucceeded;
                     }
                 },
                 else => {


### PR DESCRIPTION
There is some cleanup needed before this is ready to merge. But this solves issue #651.

As a demonstration, watch what happens when I mischeviously insert a subtle bug deep in the standard library:


```diff
--- a/std/os/child_process.zig
+++ b/std/os/child_process.zig
@@ -369,6 +369,10 @@ pub const ChildProcess = struct {
         const err_pipe = try makePipe();
         %defer destroyPipe(err_pipe);
 
+        if (self.argv[0][1] == 'n') {
+            return error.ProcessNotFound;
+        }
+
         block_SIGCHLD();
         const pid_result = posix.fork();
         const pid_err = posix.getErrno(pid_result);
```

If the 2nd character of the program we want to execute is `n` then return ProcessNotFound. Yikes, imagine trying to find this bug.

As it so happens, when we run `zig build` it will run `/nix-store/.../llvm-config` on my computer, so we can observe this getting triggered:

```
./zig build --build-file ../build.zig
```

I get this beautiful output: 
![screenshot_2018-01-12_02-07-21](https://user-images.githubusercontent.com/106511/34863571-277134fa-f73e-11e7-880f-8e96a9fe6405.png)

BOOM! We caught the culprit red-handed. Nice try!!

(here is the output in text form)

```
attempt to unwrap error: ProcessNotFound
/home/andy/dev/zig/build/lib/zig/std/os/child_process.zig:373:29: 0x0000000000270e7e in ??? (build)
        if (self.argv[0][1] == 'n') {
                            ^
/home/andy/dev/zig/build/lib/zig/std/os/child_process.zig:194:23: 0x0000000000252c45 in ??? (build)
        const child = try ChildProcess.init(argv, allocator);
                      ^
/home/andy/dev/zig/build/lib/zig/std/build.zig:735:17: 0x000000000024972d in ??? (build)
                return result.stdout;
                ^
/home/andy/dev/zig/build.zig:202:5: 0x000000000024a83a in ??? (build)
    return result;
    ^

/home/andy/dev/zig/build/lib/zig/std/special/panic.zig:19:43: 0x000000000021e892 in ??? (build)
                @import("std").debug.panic("");
                                          ^
???:?:?: 0x0000000000241f49 in ??? (???)
    ???

/home/andy/dev/zig/build.zig:50:47: 0x00000000002457f6 in ??? (build)
    const llvm = findLLVM(b, llvm_config_exe) catch unreachable;
                                              ^
/home/andy/dev/zig/build/lib/zig/std/special/build_runner.zig:115:15: 0x00000000002413cd in ??? (build)
    root.build(&builder) catch unreachable;
              ^
/home/andy/dev/zig/build/lib/zig/std/special/bootstrap.zig:65:21: 0x000000000023fa61 in ??? (build)
    return root.main();
                    ^
/home/andy/dev/zig/build/lib/zig/std/special/bootstrap.zig:54:13: 0x000000000023f8ef in ??? (build)
    callMain(argc, argv, envp) catch std.os.posix.exit(1);
            ^

Build failed. Use the following command to reproduce the failure:
./../zig-cache/build ./zig ./.. ./../zig-cache
```

Notice that if we were able to strip out these 2 stack frames (which I know how we can accomplish)...

```
/home/andy/dev/zig/build/lib/zig/std/special/panic.zig:19:43: 0x000000000021e892 in ??? (build)
                @import("std").debug.panic("");
                                          ^
???:?:?: 0x0000000000241f49 in ??? (???)
    ???
```

...then the error return trace flows directly into the stack trace. That is, the `return result` at build.zig:202 returns exactly to the beginning of the stack trace - the `catch unreachable` at build.zig:50 which is what triggered the "attempt to unwrap error".
