### PR TITLE
Add Sha3 Hash Functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -368,6 +368,7 @@ set(ZIG_STD_FILES
     "crypto/md5.zig"
     "crypto/sha1.zig"
     "crypto/sha2.zig"
+    "crypto/sha3.zig"
     "crypto/blake2.zig"
     "cstr.zig"
     "debug/failing_allocator.zig"

--- a/std/crypto/blake2.zig
+++ b/std/crypto/blake2.zig
@@ -21,6 +21,8 @@ pub const Blake2s256 = Blake2s(256);
 
 fn Blake2s(comptime out_len: usize) -> type { return struct {
     const Self = this;
+    const block_size = 64;
+    const digest_size = out_len / 8;
 
     const iv = [8]u32 {
         0x6A09E667, 0xBB67AE85, 0x3C6EF372, 0xA54FF53A,
@@ -236,6 +238,8 @@ pub const Blake2b512 = Blake2b(512);
 
 fn Blake2b(comptime out_len: usize) -> type { return struct {
     const Self = this;
+    const block_size = 128;
+    const digest_size = out_len / 8;
 
     const iv = [8]u64 {
         0x6a09e667f3bcc908, 0xbb67ae8584caa73b,

--- a/std/crypto/index.zig
+++ b/std/crypto/index.zig
@@ -7,6 +7,12 @@ pub const Sha256 = sha2.Sha256;
 pub const Sha384 = sha2.Sha384;
 pub const Sha512 = sha2.Sha512;
 
+const sha3 = @import("sha3.zig");
+pub const Sha3_224 = sha3.Sha3_224;
+pub const Sha3_256 = sha3.Sha3_256;
+pub const Sha3_384 = sha3.Sha3_384;
+pub const Sha3_512 = sha3.Sha3_512;
+
 const blake2 = @import("blake2.zig");
 pub const Blake2s224 = blake2.Blake2s224;
 pub const Blake2s256 = blake2.Blake2s256;
@@ -17,5 +23,6 @@ test "crypto" {
     _ = @import("md5.zig");
     _ = @import("sha1.zig");
     _ = @import("sha2.zig");
+    _ = @import("sha3.zig");
     _ = @import("blake2.zig");
 }

--- a/std/crypto/index.zig
+++ b/std/crypto/index.zig
@@ -1,5 +1,5 @@
-pub const Md5 = @import("sha1.zig").Md5;
-pub const Sha1 = @import("md5.zig").Sha1;
+pub const Md5 = @import("md5.zig").Md5;
+pub const Sha1 = @import("sha1.zig").Sha1;
 
 const sha2 = @import("sha2.zig");
 pub const Sha224 = sha2.Sha224;

--- a/std/crypto/md5.zig
+++ b/std/crypto/md5.zig
@@ -14,14 +14,10 @@ fn Rp(a: usize, b: usize, c: usize, d: usize, k: usize, s: u32, t: u32) -> Round
     return RoundParam { .a = a, .b = b, .c = c, .d = d, .k = k, .s = s, .t = t };
 }
 
-/// const hash1 = Md5.hash("my input");
-///
-/// const hasher = Md5.init();
-/// hasher.update("my ");
-/// hasher.update("input");
-/// const hash2 = hasher.final();
 pub const Md5 = struct {
     const Self = this;
+    const block_size = 64;
+    const digest_size = 16;
 
     s: [4]u32,
     // Streaming Cache

--- a/std/crypto/sha1.zig
+++ b/std/crypto/sha1.zig
@@ -16,6 +16,8 @@ fn Rp(a: usize, b: usize, c: usize, d: usize, e: usize, i: u32) -> RoundParam {
 
 pub const Sha1 = struct {
     const Self = this;
+    const block_size = 64;
+    const digest_size = 20;
 
     s: [5]u32,
     // Streaming Cache

--- a/std/crypto/sha2.zig
+++ b/std/crypto/sha2.zig
@@ -58,6 +58,8 @@ pub const Sha256 = Sha2_32(Sha256Params);
 
 fn Sha2_32(comptime params: Sha2Params32) -> type { return struct {
     const Self = this;
+    const block_size = 64;
+    const digest_size = params.out_len / 8;
 
     s: [8]u32,
     // Streaming Cache
@@ -372,7 +374,8 @@ pub const Sha512 = Sha2_64(Sha512Params);
 
 fn Sha2_64(comptime params: Sha2Params64) -> type { return struct {
     const Self = this;
-    const u9 = @IntType(false, 9);
+    const block_size = 128;
+    const digest_size = params.out_len / 8;
 
     s: [8]u64,
     // Streaming Cache

--- a/std/crypto/sha3.zig
+++ b/std/crypto/sha3.zig
@@ -1,0 +1,281 @@
+const mem = @import("../mem.zig");
+const math = @import("../math/index.zig");
+const endian = @import("../endian.zig");
+const debug = @import("../debug/index.zig");
+const builtin = @import("builtin");
+const htest = @import("test.zig");
+
+pub const Sha3_224 = Keccak(224, 0x06);
+pub const Sha3_256 = Keccak(256, 0x06);
+pub const Sha3_384 = Keccak(384, 0x06);
+pub const Sha3_512 = Keccak(512, 0x06);
+
+fn Keccak(comptime bits: usize, comptime delim: u8) -> type { return struct {
+    const Self = this;
+    const block_size = 200;
+    const digest_size = bits / 8;
+
+    s: [200]u8,
+    offset: usize,
+    rate: usize,
+
+    pub fn init() -> Self {
+        var d: Self = undefined;
+        d.reset();
+        return d;
+    }
+
+    pub fn reset(d: &Self) {
+        mem.set(u8, d.s[0..], 0);
+        d.offset = 0;
+        d.rate = 200 - (bits / 4);
+    }
+
+    pub fn hash(b: []const u8, out: []u8) {
+        var d = Self.init();
+        d.update(b);
+        d.final(out);
+    }
+
+    pub fn update(d: &Self, b: []const u8) {
+        var ip: usize = 0;
+        var len = b.len;
+        var rate = d.rate - d.offset;
+        var offset = d.offset;
+
+        // absorb
+        while (len >= rate) {
+            for (d.s[offset .. offset + rate]) |*r, i|
+                *r ^= b[ip..][i];
+
+            keccak_f(1600, d.s[0..]);
+
+            ip += rate;
+            len -= rate;
+            rate = d.rate;
+            offset = 0;
+        }
+
+        for (d.s[offset .. offset + len]) |*r, i|
+            *r ^= b[ip..][i];
+
+        d.offset = offset + len;
+    }
+
+    pub fn final(d: &Self, out: []u8) {
+        // padding
+        d.s[d.offset] ^= delim;
+        d.s[d.rate - 1] ^= 0x80;
+
+        keccak_f(1600, d.s[0..]);
+
+        // squeeze
+        var op: usize = 0;
+        var len: usize = bits / 8;
+
+        while (len >= d.rate) {
+            mem.copy(u8, out[op..], d.s[0..d.rate]);
+            keccak_f(1600, d.s[0..]);
+            op += d.rate;
+            len -= d.rate;
+        }
+
+        mem.copy(u8, out[op..], d.s[0..len]);
+    }
+};}
+
+const RC = []const u64 {
+    0x0000000000000001, 0x0000000000008082, 0x800000000000808a, 0x8000000080008000,
+    0x000000000000808b, 0x0000000080000001, 0x8000000080008081, 0x8000000000008009,
+    0x000000000000008a, 0x0000000000000088, 0x0000000080008009, 0x000000008000000a,
+    0x000000008000808b, 0x800000000000008b, 0x8000000000008089, 0x8000000000008003,
+    0x8000000000008002, 0x8000000000000080, 0x000000000000800a, 0x800000008000000a,
+    0x8000000080008081, 0x8000000000008080, 0x0000000080000001, 0x8000000080008008,
+};
+
+const ROTC = []const usize {
+    1, 3, 6, 10, 15, 21, 28, 36,
+    45, 55, 2, 14, 27, 41, 56, 8,
+    25, 43, 62, 18, 39, 61, 20, 44
+};
+
+const PIL = []const usize {
+    10, 7, 11, 17, 18, 3, 5, 16,
+    8, 21, 24, 4, 15, 23, 19, 13,
+    12, 2, 20, 14, 22, 9, 6, 1
+};
+
+const M5 = []const usize {
+    0, 1, 2, 3, 4, 0, 1, 2, 3, 4
+};
+
+fn keccak_f(comptime F: usize, d: []u8) {
+    debug.assert(d.len == F / 8);
+
+    const B = F / 25;
+    const no_rounds = comptime x: { break :x 12 + 2 * math.log2(B); };
+
+    var s = []const u64 {0} ** 25;
+    var t = []const u64 {0} ** 1;
+    var c = []const u64 {0} ** 5;
+
+    for (s) |*r, i| {
+        *r = mem.readIntLE(u64, d[8*i .. 8*i + 8]);
+    }
+
+    var x: usize = 0;
+    var y: usize = 0;
+    // TODO: Cannot unroll all loops here due to comptime differences.
+    inline for (RC[0..no_rounds]) |round| {
+        // theta
+        x = 0; while (x < 5) : (x += 1) {
+            c[x] = s[x] ^ s[x+5] ^ s[x+10] ^ s[x+15] ^ s[x+20];
+        }
+        x = 0; while (x < 5) : (x += 1) {
+            t[0] = c[M5[x+4]] ^ math.rotl(u64, c[M5[x+1]], usize(1));
+            y = 0; while (y < 5) : (y += 1) {
+                s[x + y*5] ^= t[0];
+            }
+        }
+
+        // rho+pi
+        t[0] = s[1];
+        x = 0; while (x < 24) : (x += 1) {
+            c[0] = s[PIL[x]];
+            s[PIL[x]] = math.rotl(u64, t[0], ROTC[x]);
+            t[0] = c[0];
+        }
+
+        // chi
+        y = 0; while (y < 5) : (y += 1) {
+            x = 0; while (x < 5) : (x += 1) {
+                c[x] = s[x + y*5];
+            }
+            x = 0; while (x < 5) : (x += 1) {
+                s[x + y*5] = c[x] ^ (~c[M5[x+1]] & c[M5[x+2]]);
+            }
+        }
+
+        // iota
+        s[0] ^= round;
+    }
+
+    for (s) |r, i| {
+        mem.writeInt(d[8*i .. 8*i + 8], r, builtin.Endian.Little);
+    }
+}
+
+
+test "sha3-224 single" {
+    htest.assertEqualHash(Sha3_224, "6b4e03423667dbb73b6e15454f0eb1abd4597f9a1b078e3f5b5a6bc7", "");
+    htest.assertEqualHash(Sha3_224, "e642824c3f8cf24ad09234ee7d3c766fc9a3a5168d0c94ad73b46fdf", "abc");
+    htest.assertEqualHash(Sha3_224, "543e6868e1666c1a643630df77367ae5a62a85070a51c14cbf665cbc", "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu");
+}
+
+test "sha3-224 streaming" {
+    var h = Sha3_224.init();
+    var out: [28]u8 = undefined;
+
+    h.final(out[0..]);
+    htest.assertEqual("6b4e03423667dbb73b6e15454f0eb1abd4597f9a1b078e3f5b5a6bc7", out[0..]);
+
+    h.reset();
+    h.update("abc");
+    h.final(out[0..]);
+    htest.assertEqual("e642824c3f8cf24ad09234ee7d3c766fc9a3a5168d0c94ad73b46fdf", out[0..]);
+
+    h.reset();
+    h.update("a");
+    h.update("b");
+    h.update("c");
+    h.final(out[0..]);
+    htest.assertEqual("e642824c3f8cf24ad09234ee7d3c766fc9a3a5168d0c94ad73b46fdf", out[0..]);
+}
+
+test "sha3-256 single" {
+    htest.assertEqualHash(Sha3_256, "a7ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a" , "");
+    htest.assertEqualHash(Sha3_256, "3a985da74fe225b2045c172d6bd390bd855f086e3e9d525b46bfe24511431532", "abc");
+    htest.assertEqualHash(Sha3_256, "916f6061fe879741ca6469b43971dfdb28b1a32dc36cb3254e812be27aad1d18", "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu");
+}
+
+test "sha3-256 streaming" {
+    var h = Sha3_256.init();
+    var out: [32]u8 = undefined;
+
+    h.final(out[0..]);
+    htest.assertEqual("a7ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a", out[0..]);
+
+    h.reset();
+    h.update("abc");
+    h.final(out[0..]);
+    htest.assertEqual("3a985da74fe225b2045c172d6bd390bd855f086e3e9d525b46bfe24511431532", out[0..]);
+
+    h.reset();
+    h.update("a");
+    h.update("b");
+    h.update("c");
+    h.final(out[0..]);
+    htest.assertEqual("3a985da74fe225b2045c172d6bd390bd855f086e3e9d525b46bfe24511431532", out[0..]);
+}
+
+test "sha3-384 single" {
+    const h1 = "0c63a75b845e4f7d01107d852e4c2485c51a50aaaa94fc61995e71bbee983a2ac3713831264adb47fb6bd1e058d5f004";
+    htest.assertEqualHash(Sha3_384, h1 , "");
+    const h2 = "ec01498288516fc926459f58e2c6ad8df9b473cb0fc08c2596da7cf0e49be4b298d88cea927ac7f539f1edf228376d25";
+    htest.assertEqualHash(Sha3_384, h2, "abc");
+    const h3 = "79407d3b5916b59c3e30b09822974791c313fb9ecc849e406f23592d04f625dc8c709b98b43b3852b337216179aa7fc7";
+    htest.assertEqualHash(Sha3_384, h3, "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu");
+}
+
+test "sha3-384 streaming" {
+    var h = Sha3_384.init();
+    var out: [48]u8 = undefined;
+
+    const h1 = "0c63a75b845e4f7d01107d852e4c2485c51a50aaaa94fc61995e71bbee983a2ac3713831264adb47fb6bd1e058d5f004";
+    h.final(out[0..]);
+    htest.assertEqual(h1, out[0..]);
+
+    const h2 = "ec01498288516fc926459f58e2c6ad8df9b473cb0fc08c2596da7cf0e49be4b298d88cea927ac7f539f1edf228376d25";
+    h.reset();
+    h.update("abc");
+    h.final(out[0..]);
+    htest.assertEqual(h2, out[0..]);
+
+    h.reset();
+    h.update("a");
+    h.update("b");
+    h.update("c");
+    h.final(out[0..]);
+    htest.assertEqual(h2, out[0..]);
+}
+
+test "sha3-512 single" {
+    const h1 = "a69f73cca23a9ac5c8b567dc185a756e97c982164fe25859e0d1dcc1475c80a615b2123af1f5f94c11e3e9402c3ac558f500199d95b6d3e301758586281dcd26";
+    htest.assertEqualHash(Sha3_512, h1 , "");
+    const h2 = "b751850b1a57168a5693cd924b6b096e08f621827444f70d884f5d0240d2712e10e116e9192af3c91a7ec57647e3934057340b4cf408d5a56592f8274eec53f0";
+    htest.assertEqualHash(Sha3_512, h2, "abc");
+    const h3 = "afebb2ef542e6579c50cad06d2e578f9f8dd6881d7dc824d26360feebf18a4fa73e3261122948efcfd492e74e82e2189ed0fb440d187f382270cb455f21dd185";
+    htest.assertEqualHash(Sha3_512, h3, "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu");
+}
+
+test "sha3-512 streaming" {
+    var h = Sha3_512.init();
+    var out: [64]u8 = undefined;
+
+    const h1 = "a69f73cca23a9ac5c8b567dc185a756e97c982164fe25859e0d1dcc1475c80a615b2123af1f5f94c11e3e9402c3ac558f500199d95b6d3e301758586281dcd26";
+    h.final(out[0..]);
+    htest.assertEqual(h1, out[0..]);
+
+    const h2 = "b751850b1a57168a5693cd924b6b096e08f621827444f70d884f5d0240d2712e10e116e9192af3c91a7ec57647e3934057340b4cf408d5a56592f8274eec53f0";
+    h.reset();
+    h.update("abc");
+    h.final(out[0..]);
+    htest.assertEqual(h2, out[0..]);
+
+    h.reset();
+    h.update("a");
+    h.update("b");
+    h.update("c");
+    h.final(out[0..]);
+    htest.assertEqual(h2, out[0..]);
+}

--- a/std/crypto/throughput_test.zig
+++ b/std/crypto/throughput_test.zig
@@ -1,0 +1,43 @@
+// Modify the HashFunction variable to the one wanted to test.
+//
+// NOTE: The throughput measurement may be slightly lower than other measurements since we run
+// through our block alignment functions as well. Be aware when comparing against other tests.
+//
+// ```
+// zig build-exe --release-fast --library c throughput_test.zig
+// ./throughput_test
+// ```
+const HashFunction = @import("md5.zig").Md5;
+const BytesToHash  = 1024 * Mb;
+
+const std = @import("std");
+
+const c = @cImport({
+    @cInclude("time.h");
+});
+
+const Mb = 1024 * 1024;
+
+pub fn main() -> %void {
+    var stdout_file = try std.io.getStdOut();
+    var stdout_out_stream = std.io.FileOutStream.init(&stdout_file);
+    const stdout = &stdout_out_stream.stream;
+
+    var block: [HashFunction.block_size]u8 = undefined;
+    std.mem.set(u8, block[0..], 0);
+
+    var h = HashFunction.init();
+    var offset: usize = 0;
+
+    const start = c.clock();
+    while (offset < BytesToHash) : (offset += block.len) {
+        h.update(block[0..]);
+    }
+    const end = c.clock();
+
+    const elapsed_s = f64((end - start) * c.CLOCKS_PER_SEC) / 1000000;
+    const throughput = u64(BytesToHash / elapsed_s);
+
+    try stdout.print("{}: ", @typeName(HashFunction));
+    try stdout.print("{} Mb/s\n", throughput);
+}


### PR DESCRIPTION
These are on the slower side and could be improved. No performance optimizations
yet have been done.

```
Cpu: Intel(R) Core(TM) i5-6500 CPU @ 3.20GHz
```

# Sha3-256

```
Zig --release-fast
    93 Mb/s
Zig --release-safe
    99 Mb/s
Zig
    4 Mb/s
```

# Sha3-512

```
Zig --release-fast
    49 Mb/s
Zig --release-safe
    54 Mb/s
Zig
    2 Mb/s
```

Interestingly, release-safe is producing slightly better code than
release-fast.

Also, the blake numbers which I hadn't measured on their commit:

# Blake2s

```
Zig --release-fast
    485 Mb/s
Zig --release-safe
    377 Mb/s
Zig
    11 Mb/s
```

# Blake2b
```
Zig --release-fast
    616 Mb/s
Zig --release-safe
    573 Mb/s
Zig
    18 Mb/s
```