### PR TITLE
Add array type handling for gen_h

### DIFF
--- a/test/gen_h.zig
+++ b/test/gen_h.zig
@@ -50,4 +50,20 @@ pub fn addCases(cases: &tests.GenHContext) {
         \\TEST_EXPORT void entry(union Foo foo);
         \\
     );
+
+    cases.add("array field-type",
+        \\const Foo = extern struct {
+        \\    A: [2]i32,
+        \\    B: [4]&u32,
+        \\};
+        \\export fn entry(foo: Foo, bar: [3]u8) { }
+    ,
+        \\struct Foo {
+        \\    int32_t A[2];
+        \\    uint32_t * B[4];
+        \\};
+        \\
+        \\TEST_EXPORT void entry(struct Foo foo, uint8_t bar[]);
+        \\
+    );
 }


### PR DESCRIPTION
Haven't thought hard about edge cases here. Actually just realised this doesn't handle multi-dimensional arrays. This is better than the status quo at least.