### PR TITLE
Made Zig support tabs

### DIFF
--- a/src-self-hosted/tokenizer.zig
+++ b/src-self-hosted/tokenizer.zig
@@ -227,7 +227,7 @@ pub const Tokenizer = struct {
             const c = self.buffer[self.index];
             switch (state) {
                 State.Start => switch (c) {
-                    ' ', '\n' => {
+                    ' ', '\t', '\n' => {
                         result.start = self.index + 1;
                     },
                     'c' => {

--- a/src/tokenizer.cpp
+++ b/src/tokenizer.cpp
@@ -17,6 +17,7 @@
 
 #define WHITESPACE \
          ' ': \
+    case '\t': \
     case '\n'
 
 #define DIGIT_NON_ZERO \


### PR DESCRIPTION
I'd say this is a fairly common sense thing to do. Whitespace styles have no effect on identifier names or anything else that could alter compatibility between different pieces of Zig code. It's also something that's incredibly easy to alter after the code is written: just put the code through a formatter and you're done. Besides, there are reasonable reasons for using both spaces and tabs for indenting: it's not as if one is objectively better than another. Compiler errors should be reserved for things that are objectively incorrect or have the ability to produce compatibility problems (such as non-standard case in public identifier names), not superficial styling choices.