### PR TITLE
add CLANG_LIBDIRS cmake build variable

### DIFF
--- a/cmake/Findclang.cmake
+++ b/cmake/Findclang.cmake
@@ -5,6 +5,7 @@
 # CLANG_FOUND
 # CLANG_INCLUDE_DIRS
 # CLANG_LIBRARIES
+# CLANG_LIBDIRS
 
 if(MSVC)
   find_package(CLANG REQUIRED CONFIG)
@@ -34,6 +35,7 @@ else()
       string(TOUPPER ${_libname_} _prettylibname_)
       find_library(CLANG_${_prettylibname_}_LIB NAMES ${_libname_}
           PATHS
+              ${CLANG_LIBDIRS}
               /usr/lib/llvm/6/lib
               /usr/lib/llvm-6.0/lib
               /mingw64/lib
@@ -60,4 +62,4 @@ endif()
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(CLANG DEFAULT_MSG CLANG_LIBRARIES CLANG_INCLUDE_DIRS)
 
-mark_as_advanced(CLANG_INCLUDE_DIRS CLANG_LIBRARIES)
+mark_as_advanced(CLANG_INCLUDE_DIRS CLANG_LIBRARIES CLANG_LIBDIRS)

--- a/cmake/Findllvm.cmake
+++ b/cmake/Findllvm.cmake
@@ -66,7 +66,7 @@ if(NOT LLVM_LIBRARIES)
 endif()
 
 link_directories("${CMAKE_PREFIX_PATH}/lib")
-
+link_directories("${LLVM_LIBDIRS}")
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(LLVM DEFAULT_MSG LLVM_LIBRARIES LLVM_INCLUDE_DIRS)


### PR DESCRIPTION
Mirrors LLVM_LIBDIRS, tells cmake where to look for libclang libraries.

The second commit fixes the build for me with a llvm that lives in $HOME/llvm/lib.