### PR TITLE
Add run compiler command

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -6289,7 +6289,7 @@ static ImportTableEntry *add_special_code(CodeGen *g, PackageTableEntry *package
         zig_panic("unable to open '%s': %s", buf_ptr(&path_to_code_src), err_str(err));
     }
     Buf *import_code = buf_alloc();
-    if ((err = os_fetch_file_path(abs_full_path, import_code))) {
+    if ((err = os_fetch_file_path(abs_full_path, import_code, false))) {
         zig_panic("unable to open '%s': %s", buf_ptr(&path_to_code_src), err_str(err));
     }
 
@@ -6377,7 +6377,7 @@ static void gen_root_source(CodeGen *g) {
     }
 
     Buf *source_code = buf_alloc();
-    if ((err = os_fetch_file_path(rel_full_path, source_code))) {
+    if ((err = os_fetch_file_path(rel_full_path, source_code, true))) {
         zig_panic("unable to open '%s': %s", buf_ptr(rel_full_path), err_str(err));
     }
 
@@ -6442,7 +6442,7 @@ static void gen_global_asm(CodeGen *g) {
     int err;
     for (size_t i = 0; i < g->assembly_files.length; i += 1) {
         Buf *asm_file = g->assembly_files.at(i);
-        if ((err = os_fetch_file_path(asm_file, &contents))) {
+        if ((err = os_fetch_file_path(asm_file, &contents,  false))) {
             zig_panic("Unable to read %s: %s", buf_ptr(asm_file), err_str(err));
         }
         buf_append_buf(&g->global_asm, &contents);

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -14709,7 +14709,7 @@ static TypeTableEntry *ir_analyze_instruction_import(IrAnalyze *ira, IrInstructi
         return ira->codegen->builtin_types.entry_namespace;
     }
 
-    if ((err = os_fetch_file_path(abs_full_path, import_code))) {
+    if ((err = os_fetch_file_path(abs_full_path, import_code, true))) {
         if (err == ErrorFileNotFound) {
             ir_add_error_node(ira, source_node,
                     buf_sprintf("unable to find '%s'", buf_ptr(import_target_path)));
@@ -15570,7 +15570,7 @@ static TypeTableEntry *ir_analyze_instruction_embed_file(IrAnalyze *ira, IrInstr
     // load from file system into const expr
     Buf *file_contents = buf_alloc();
     int err;
-    if ((err = os_fetch_file_path(&file_path, file_contents))) {
+    if ((err = os_fetch_file_path(&file_path, file_contents, false))) {
         if (err == ErrorFileNotFound) {
             ir_add_error(ira, instruction->name, buf_sprintf("unable to find '%s'", buf_ptr(&file_path)));
             return ira->codegen->builtin_types.entry_invalid;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,6 +23,7 @@ static int usage(const char *arg0) {
         "  build-exe [source]           create executable from source or object files\n"
         "  build-lib [source]           create library from source or object files\n"
         "  build-obj [source]           create object from source or assembly\n"
+        "  run [source]                 create executable and run immediately\n"
         "  translate-c [source]         convert c code to zig code\n"
         "  targets                      list available compilation targets\n"
         "  test [source]                create and run a test build\n"
@@ -227,6 +228,7 @@ static Buf *resolve_zig_lib_dir(const char *zig_install_prefix_arg) {
 enum Cmd {
     CmdInvalid,
     CmdBuild,
+    CmdRun,
     CmdTest,
     CmdVersion,
     CmdZen,
@@ -336,6 +338,8 @@ int main(int argc, char **argv) {
     CliPkg *cur_pkg = allocate<CliPkg>(1);
     BuildMode build_mode = BuildModeDebug;
     ZigList<const char *> test_exec_args = {0};
+    int comptime_args_end = 0;
+    int runtime_args_start = argc;
 
     if (argc >= 2 && strcmp(argv[1], "build") == 0) {
         const char *zig_exe_path = arg0;
@@ -488,11 +492,15 @@ int main(int argc, char **argv) {
         return (term.how == TerminationIdClean) ? term.code : -1;
     }
 
-    for (int i = 1; i < argc; i += 1) {
+    for (int i = 1; i < argc; i += 1, comptime_args_end += 1) {
         char *arg = argv[i];
 
         if (arg[0] == '-') {
-            if (strcmp(arg, "--release-fast") == 0) {
+            if (strcmp(arg, "--") == 0) {
+                // ignore -- from both compile and runtime arg sets
+                runtime_args_start = i + 1;
+                break;
+            } else if (strcmp(arg, "--release-fast") == 0) {
                 build_mode = BuildModeFastRelease;
             } else if (strcmp(arg, "--release-safe") == 0) {
                 build_mode = BuildModeSafeRelease;
@@ -659,6 +667,9 @@ int main(int argc, char **argv) {
             } else if (strcmp(arg, "build-lib") == 0) {
                 cmd = CmdBuild;
                 out_type = OutTypeLib;
+            } else if (strcmp(arg, "run") == 0) {
+                cmd = CmdRun;
+                out_type = OutTypeExe;
             } else if (strcmp(arg, "version") == 0) {
                 cmd = CmdVersion;
             } else if (strcmp(arg, "zen") == 0) {
@@ -677,6 +688,7 @@ int main(int argc, char **argv) {
         } else {
             switch (cmd) {
                 case CmdBuild:
+                case CmdRun:
                 case CmdTranslateC:
                 case CmdTest:
                     if (!in_file) {
@@ -731,8 +743,8 @@ int main(int argc, char **argv) {
         }
     }
 
-
     switch (cmd) {
+    case CmdRun:
     case CmdBuild:
     case CmdTranslateC:
     case CmdTest:
@@ -740,7 +752,7 @@ int main(int argc, char **argv) {
             if (cmd == CmdBuild && !in_file && objects.length == 0 && asm_files.length == 0) {
                 fprintf(stderr, "Expected source file argument or at least one --object or --assembly argument.\n");
                 return usage(arg0);
-            } else if ((cmd == CmdTranslateC || cmd == CmdTest) && !in_file) {
+            } else if ((cmd == CmdTranslateC || cmd == CmdTest || cmd == CmdRun) && !in_file) {
                 fprintf(stderr, "Expected source file argument.\n");
                 return usage(arg0);
             } else if (cmd == CmdBuild && out_type == OutTypeObj && objects.length != 0) {
@@ -751,6 +763,10 @@ int main(int argc, char **argv) {
             assert(cmd != CmdBuild || out_type != OutTypeUnknown);
 
             bool need_name = (cmd == CmdBuild || cmd == CmdTranslateC);
+
+            if (cmd == CmdRun) {
+                out_name = "run";
+            }
 
             Buf *in_file_buf = nullptr;
 
@@ -776,9 +792,23 @@ int main(int argc, char **argv) {
             Buf *zig_root_source_file = (cmd == CmdTranslateC) ? nullptr : in_file_buf;
 
             Buf *full_cache_dir = buf_alloc();
-            os_path_resolve(buf_create_from_str("."),
-                    buf_create_from_str((cache_dir == nullptr) ? default_zig_cache_name : cache_dir),
-                    full_cache_dir);
+            Buf *run_exec_path = buf_alloc();
+            if (cmd == CmdRun) {
+                if (buf_out_name == nullptr) {
+                    buf_out_name = buf_create_from_str("run");
+                }
+
+                Buf *global_cache_dir = buf_alloc();
+                os_get_global_cache_directory(global_cache_dir);
+                os_path_join(global_cache_dir, buf_out_name, run_exec_path);
+                os_path_resolve(buf_create_from_str("."), global_cache_dir, full_cache_dir);
+
+                out_file = buf_ptr(run_exec_path);
+            } else {
+                os_path_resolve(buf_create_from_str("."),
+                        buf_create_from_str((cache_dir == nullptr) ? default_zig_cache_name : cache_dir),
+                        full_cache_dir);
+            }
 
             Buf *zig_lib_dir_buf = resolve_zig_lib_dir(zig_install_prefix);
 
@@ -862,7 +892,7 @@ int main(int argc, char **argv) {
 
             add_package(g, cur_pkg, g->root_package);
 
-            if (cmd == CmdBuild) {
+            if (cmd == CmdBuild || cmd == CmdRun) {
                 codegen_set_emit_file_type(g, emit_file_type);
 
                 for (size_t i = 0; i < objects.length; i += 1) {
@@ -875,6 +905,18 @@ int main(int argc, char **argv) {
                 codegen_link(g, out_file);
                 if (timing_info)
                     codegen_print_timing_report(g, stdout);
+
+                if (cmd == CmdRun) {
+                    ZigList<const char*> args = {0};
+                    for (int i = runtime_args_start; i < argc; ++i) {
+                        args.append(argv[i]);
+                    }
+
+                    Termination term;
+                    os_spawn_process(buf_ptr(run_exec_path), args, &term);
+                    return term.code;
+                }
+
                 return EXIT_SUCCESS;
             } else if (cmd == CmdTranslateC) {
                 codegen_translate_c(g, in_file_buf);

--- a/src/os.hpp
+++ b/src/os.hpp
@@ -51,14 +51,16 @@ int os_path_real(Buf *rel_path, Buf *out_abs_path);
 void os_path_resolve(Buf *ref_path, Buf *target_path, Buf *out_abs_path);
 bool os_path_is_absolute(Buf *path);
 
+int os_get_global_cache_directory(Buf *out_tmp_path);
+
 int os_make_path(Buf *path);
 int os_make_dir(Buf *path);
 
 void os_write_file(Buf *full_path, Buf *contents);
 int os_copy_file(Buf *src_path, Buf *dest_path);
 
-int os_fetch_file(FILE *file, Buf *out_contents);
-int os_fetch_file_path(Buf *full_path, Buf *out_contents);
+int os_fetch_file(FILE *file, Buf *out_contents, bool skip_shebang);
+int os_fetch_file_path(Buf *full_path, Buf *out_contents, bool skip_shebang);
 
 int os_get_cwd(Buf *out_cwd);
 


### PR DESCRIPTION
See #466.

This is fairly simplistic and doesn't implement all the ideas from the proposal but I think it'll cover the vast majority of use cases right now. Summary of the features below.

A little messy, I have some visions for how I'd like to see the compiler cli but that's another issue. Also untested on Windows but provided I implemented the os details without compiler errors they should do the job.

I've skimped on tests for the moment.

Here is a simple test program that can be used to verify arguments (modify the shebang location to suit).

```
#!/home/me/local/bin/zig run

const std = @import("std");
const os = std.os;

const allocator = std.debug.global_allocator;

pub fn main() void {
    var args_it = os.args();

    while (args_it.next(allocator)) |arg_or_err| {
        std.debug.warn("{}\n", arg_or_err);
    }
}
```

---

`zig run file.zig` builds a file and stores the artifacts in the global
cache. On successful compilation the binary is executed.

`zig run file.zig -- a b c` does the same, but passes the arguments a,
b and c as runtime arguments to the program. Everything after an `--` are
treated as runtime arguments.

If the file was not modified or renamed and the compile arguments have not
changed (order cannot change either) then a cached version may be used
instead of recompiling. Runtime arguments do not trigger a rebuild.

On a posix system, a shebang can be used to run a zig file directly. An
example shebang would be `#!/usr/bin/zig run`. You may not be able pass
extra compile arguments currently as part of the shebang. Linux for example
treats all arguments after the first as a single argument which will result
in an 'invalid command'.

Currently there is no customisability for the cache path as a compile
argument. For a posix system you can use `TMPDIR=. zig run file.zig` to
override, in this case using the current directory for the run cache.

Closes #466.