### PR TITLE
Ignores .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 zig-cache/
 build/
 build-*/
+.DS_Store


### PR DESCRIPTION
Adds `.DS_Store` to the `.gitignore` for people working on macOS