### PR TITLE
fix llvm assert on version string with git sha

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -6207,7 +6207,9 @@ static void init(CodeGen *g) {
     g->builder = LLVMCreateBuilder();
     g->dbuilder = ZigLLVMCreateDIBuilder(g->module, true);
 
-    Buf *producer = buf_sprintf("zig %s", ZIG_VERSION_STRING);
+    // Don't use ZIG_VERSION_STRING here, llvm misparses it when it includes
+    // the git revision.
+    Buf *producer = buf_sprintf("zig %d.%d.%d", ZIG_VERSION_MAJOR, ZIG_VERSION_MINOR, ZIG_VERSION_PATCH);
     const char *flags = "";
     unsigned runtime_version = 0;
     ZigLLVMDIFile *compile_unit_file = ZigLLVMCreateFile(g->dbuilder, buf_ptr(g->root_out_name),


### PR DESCRIPTION
LLVM's CodeViewDebug pass misparses the version string when it contains
a git revision so stop doing that.  This only affected Windows builds.

closes #898