### PR TITLE
Add exp/norm distributed random float generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -515,6 +515,7 @@ set(ZIG_STD_FILES
     "os/windows/util.zig"
     "os/zen.zig"
     "rand/index.zig"
+    "rand/ziggurat.zig"
     "sort.zig"
     "special/bootstrap.zig"
     "special/bootstrap_lib.zig"

--- a/std/rand/index.zig
+++ b/std/rand/index.zig
@@ -19,6 +19,7 @@ const builtin = @import("builtin");
 const assert = std.debug.assert;
 const mem = std.mem;
 const math = std.math;
+const ziggurat = @import("ziggurat.zig");
 
 // When you need fast unbiased random numbers
 pub const DefaultPrng = Xoroshiro128;
@@ -109,15 +110,28 @@ pub const Random = struct {
         }
     }
 
-    /// Return a floating point value normally distributed in the range [0, 1].
+    /// Return a floating point value normally distributed with mean = 0, stddev = 1.
+    ///
+    /// To use different parameters, use: floatNorm(...) * desiredStddev + desiredMean.
     pub fn floatNorm(r: &Random, comptime T: type) T {
-        // TODO(tiehuis): See https://www.doornik.com/research/ziggurat.pdf
-        @compileError("floatNorm is unimplemented");
+        const value = ziggurat.next_f64(r, ziggurat.NormDist);
+        switch (T) {
+            f32 => return f32(value),
+            f64 => return value,
+            else => @compileError("unknown floating point type"),
+        }
     }
 
-    /// Return a exponentially distributed float between (0, @maxValue(f64))
+    /// Return an exponentially distributed float with a rate parameter of 1.
+    ///
+    /// To use a different rate parameter, use: floatExp(...) / desiredRate.
     pub fn floatExp(r: &Random, comptime T: type) T {
-        @compileError("floatExp is unimplemented");
+        const value = ziggurat.next_f64(r, ziggurat.ExpDist);
+        switch (T) {
+            f32 => return f32(value),
+            f64 => return value,
+            else => @compileError("unknown floating point type"),
+        }
     }
 
     /// Shuffle a slice into a random order.

--- a/std/rand/ziggurat.zig
+++ b/std/rand/ziggurat.zig
@@ -1,0 +1,146 @@
+// Implements ZIGNOR [1].
+//
+// [1]: Jurgen A. Doornik (2005). [*An Improved Ziggurat Method to Generate Normal Random Samples*]
+// (https://www.doornik.com/research/ziggurat.pdf). Nuffield College, Oxford.
+//
+// rust/rand used as a reference;
+//
+// NOTE: This seems interesting but reference code is a bit hard to grok:
+// https://sbarral.github.io/etf.
+
+const std = @import("../index.zig");
+const math = std.math;
+const Random = std.rand.Random;
+
+pub fn next_f64(random: &Random, comptime tables: &const ZigTable) f64 {
+    while (true) {
+        // We manually construct a float from parts as we can avoid an extra random lookup here by
+        // using the unused exponent for the lookup table entry.
+        const bits = random.scalar(u64);
+        const i = usize(bits & 0xff);
+
+        const u = blk: {
+            if (tables.is_symmetric) {
+                // Generate a value in the range [2, 4) and scale into [-1, 1)
+                const repr = ((0x3ff + 1) << 52) | (bits >> 12);
+                break :blk @bitCast(f64, repr) - 3.0;
+            } else {
+                // Generate a value in the range [1, 2) and scale into (0, 1)
+                const repr = (0x3ff << 52) | (bits >> 12);
+                break :blk @bitCast(f64, repr) - (1.0 - math.f64_epsilon / 2.0);
+            }
+        };
+
+        const x = u * tables.x[i];
+        const test_x = if (tables.is_symmetric) math.fabs(x) else x;
+
+        // equivalent to |u| < tables.x[i+1] / tables.x[i] (or u < tables.x[i+1] / tables.x[i])
+        if (test_x < tables.x[i + 1]) {
+            return x;
+        }
+
+        if (i == 0) {
+            return tables.zero_case(random, u);
+        }
+
+        // equivalent to f1 + DRanU() * (f0 - f1) < 1
+        if (tables.f[i + 1] + (tables.f[i] - tables.f[i + 1]) * random.float(f64) < tables.pdf(x)) {
+            return x;
+        }
+    }
+}
+
+pub const ZigTable = struct {
+    r: f64,
+    x: [257]f64,
+    f: [257]f64,
+
+    // probability density function used as a fallback
+    pdf: fn(f64) f64,
+    // whether the distribution is symmetric
+    is_symmetric: bool,
+    // fallback calculation in the case we are in the 0 block
+    zero_case: fn(&Random, f64) f64,
+};
+
+// zigNorInit
+fn ZigTableGen(comptime is_symmetric: bool, comptime r: f64, comptime v: f64, comptime f: fn(f64) f64,
+       comptime f_inv: fn(f64) f64, comptime zero_case: fn(&Random, f64) f64) ZigTable {
+    var tables: ZigTable = undefined;
+
+    tables.is_symmetric = is_symmetric;
+    tables.r = r;
+    tables.pdf = f;
+    tables.zero_case = zero_case;
+
+    tables.x[0] = v / f(r);
+    tables.x[1] = r;
+
+    for (tables.x[2..256]) |*entry, i| {
+        const last = tables.x[2 + i - 1];
+        *entry = f_inv(v / last + f(last));
+    }
+    tables.x[256] = 0;
+
+    for (tables.f[0..]) |*entry, i| {
+        *entry = f(tables.x[i]);
+    }
+
+    return tables;
+}
+
+// N(0, 1)
+pub const NormDist = blk: {
+    @setEvalBranchQuota(30000);
+    break :blk ZigTableGen(true, norm_r, norm_v, norm_f, norm_f_inv, norm_zero_case);
+};
+
+const norm_r = 3.6541528853610088;
+const norm_v = 0.00492867323399;
+
+fn norm_f(x: f64) f64 { return math.exp(-x * x / 2.0); }
+fn norm_f_inv(y: f64) f64 { return math.sqrt(-2.0 * math.ln(y)); }
+fn norm_zero_case(random: &Random, u: f64) f64 {
+    var x: f64 = 1;
+    var y: f64 = 0;
+
+    while (-2.0 * y < x * x) {
+        x = math.ln(random.float(f64)) / norm_r;
+        y = math.ln(random.float(f64));
+    }
+
+    if (u < 0) {
+        return x - norm_r;
+    } else {
+        return norm_r - x;
+    }
+}
+
+test "ziggurant normal dist sanity" {
+    var prng = std.rand.DefaultPrng.init(0);
+    var i: usize = 0;
+    while (i < 1000) : (i += 1) {
+        _ = prng.random.floatNorm(f64);
+    }
+}
+
+// Exp(1)
+pub const ExpDist = blk: {
+    @setEvalBranchQuota(30000);
+    break :blk ZigTableGen(false, exp_r, exp_v, exp_f, exp_f_inv, exp_zero_case);
+};
+
+const exp_r = 7.69711747013104972;
+const exp_v = 0.0039496598225815571993;
+
+fn exp_f(x: f64) f64 { return math.exp(-x); }
+fn exp_f_inv(y: f64) f64 { return -math.ln(y); }
+fn exp_zero_case(random: &Random, _: f64) f64 { return exp_r - math.ln(random.float(f64)); }
+
+test "ziggurant exp dist sanity" {
+    var prng = std.rand.DefaultPrng.init(0);
+    var i: usize = 0;
+    while (i < 1000) : (i += 1) {
+        _ = prng.random.floatExp(f64);
+    }
+}


### PR DESCRIPTION
Had actually finished this two weeks ago but the compile-time bug (#920) made me go on a bit of a tangent.

We cache the normal table at runtime now since there is a pending issue evaluating at compile-time. We also disable the hardware sqrt as we don't have a way of falling back to the software implementation, or using the llvm instrinsics at compile-time just yet.

I haven't added any specific tests for the distributions, but I've verified with the following sample programs. We take a few samples using the zig implementation and compare it against go and also visually to against the distribution we would expect. See the end for source for the tests.

# Exponential Distribution

![zig_exp](https://user-images.githubusercontent.com/4605603/38766767-dbccf65c-402a-11e8-8b11-0ec31eadd477.png)

![go_exp](https://user-images.githubusercontent.com/4605603/38766769-e6bef31c-402a-11e8-98f1-f7469ce052a5.png)

# Normal Distribution

![zig_norm](https://user-images.githubusercontent.com/4605603/38766774-eb80af76-402a-11e8-9a65-38c3c5de0f65.png)

![go_norm](https://user-images.githubusercontent.com/4605603/38766775-edf7ae44-402a-11e8-871e-52e6b95d8f58.png)

---

### Test Programs

```sh
zig run main.zig > zig_norm_out
python show.py zig_norm_out
```

```
// main.zig

const std = @import("std");
const DefaultPrng = std.rand.DefaultPrng;

pub fn main() !void {
    var stdout_file = try std.io.getStdOut();
    var out_stream = &std.io.FileOutStream.init(&stdout_file).stream;

    var prng = DefaultPrng.init(0);

    var i: usize = 0;
    while (i < 100000) : (i += 1) {
        // use floatExp to test exp
        try out_stream.print("{}\n", prng.random.floatNorm(f64));
    }
}
```

```go
// main.go

package main

import (
	"fmt"
	"math/rand"
	"time"
)

func main() {
	r := rand.New(rand.NewSource(time.Now().UnixNano()))
	for i := 0; i < 100000; i++ {
		// use ExpFloat64 to test exp
		fmt.Printf("%f\n", r.NormFloat64())
	}
}
```

```python
# show.py

import sys
import numpy as np
import matplotlib.pyplot as plt

a = np.fromfile(open(sys.argv[1], 'r'), sep='\n')

bins = []

len = 6
binc = 500
step = len / binc

z = 0 - len / 2
for i in range(0, binc + 1):
    bins.append(z)
    z += step

plt.hist(a, bins=bins)
plt.title(sys.argv[1])
plt.show()
```
