### PR TITLE
Functional Module: Map/Reduce/Filter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -544,6 +544,7 @@ set(ZIG_STD_FILES
     "special/panic.zig"
     "special/test_runner.zig"
     "unicode.zig"
+    "functional.zig"
     "zig/ast.zig"
     "zig/index.zig"
     "zig/parser.zig"

--- a/std/functional.zig
+++ b/std/functional.zig
@@ -1,0 +1,78 @@
+// A series of functional helpers
+const std = @import("index.zig");
+const debug = std.debug;
+const assert = debug.assert;
+const mem = std.mem;
+
+pub fn map(comptime listType: type, comptime outType: type, func: fn (listType)outType, list: []const listType, buffer: []outType) []outType {
+    assert(buffer.len >= list.len);
+    for (list) |item, i| {
+        buffer[i] = func(item);
+    }
+    return buffer[0..list.len];
+}
+
+// You have to free the result
+pub fn mapAlloc(comptime listType: type, comptime outType: type, func: fn (listType)outType, list: []const listType, allocator: &mem.Allocator) ![]outType {
+    var buf = try allocator.alloc(outType, list.len);
+    return map(listType, outType, func, list, buf);
+}
+
+test "functional.map" {
+    var direct_allocator = std.heap.DirectAllocator.init();
+    defer direct_allocator.deinit();
+    assert(mem.eql(i32, try mapAlloc(i32, i32, test_pow, ([]i32{ 1, 4, 5, 2, 8 })[0..], &direct_allocator.allocator), []i32{ 1, 16, 25, 4, 64 }));
+}
+
+pub fn filter(comptime listType: type, func: fn(listType)bool, list: []const listType, buffer: []listType) []listType {
+    // You have to be prepared that the reduce will match all
+    assert(buffer.len >= list.len);
+    var count : usize = 0;
+    for (list) |item, i| {
+        if (func(item)) {
+            buffer[count] = item;
+            count += 1;
+        }
+    }
+    return buffer[0..count];
+}
+
+// You have to free the result
+pub fn filterAlloc(comptime listType: type, func: fn (listType)bool, list: []const listType, allocator: &mem.Allocator) ![]listType {
+    // We can't know how much to allocate so we will over allocate
+    // Then shrink to prevent annoyance for developer
+    var buf = try allocator.alloc(listType, list.len);
+    var out = filter(listType, func, list, buf);
+    // Actual size we needed
+    return allocator.shrink(listType, buf, out.len);
+}
+
+test "functional.filter" {
+    var direct_allocator = std.heap.DirectAllocator.init();
+    defer direct_allocator.deinit();
+    assert(mem.eql(i32, try filterAlloc(i32, test_is_even, ([]i32{ 1, 4, 5, 2, 8 })[0..], &direct_allocator.allocator), []i32{ 4, 2, 8 }));
+}
+
+pub fn reduce(comptime listType: type, func: fn(listType, listType)listType, list: []const listType) listType {
+    var out : listType = list[0];
+    for (list[1..]) |item| {
+        out = func(out, item);
+    }
+    return out;
+}
+
+test "functional.reduce" {
+    assert(reduce(i32, test_add, ([]i32{ 1, 3, 14 })[0..]) == 42);
+}
+
+fn test_is_even(a: i32)bool {
+    return @rem(a, 2) == 0;
+}
+
+fn test_add(a: i32, b: i32)i32 { 
+    return a * b;
+}
+
+fn test_pow(a: i32) i32 {
+    return a * a;
+}

--- a/std/functional.zig
+++ b/std/functional.zig
@@ -4,6 +4,8 @@ const debug = std.debug;
 const assert = debug.assert;
 const mem = std.mem;
 
+// Maps all of an arrays items to a function
+// Returning the composition of each item with the function as a new array
 pub fn map(func: var, list: []const @ArgType(@typeOf(func), 0), buffer: []@typeOf(func).ReturnType) []@typeOf(func).ReturnType {
     assert(buffer.len >= list.len);
     for (list) |item, i| {
@@ -12,6 +14,8 @@ pub fn map(func: var, list: []const @ArgType(@typeOf(func), 0), buffer: []@typeO
     return buffer[0..list.len];
 }
 
+// Maps all of an arrays items to a function
+// Returning the composition of each item with the function as a new array
 // You have to free the result
 pub fn mapAlloc(func: var, list: []const @ArgType(@typeOf(func), 0), allocator: &mem.Allocator) ![]@typeOf(func).ReturnType {
     var buf = try allocator.alloc(@typeOf(func).ReturnType, list.len);
@@ -24,6 +28,7 @@ test "functional.map" {
     assert(mem.eql(i32, try mapAlloc(test_pow, ([]i32{ 1, 4, 5, 2, 8 })[0..], &direct_allocator.allocator), []i32{ 1, 16, 25, 4, 64 }));
 }
 
+// Returns a new array including items only where the filter function returned true
 pub fn filter(func: var, list: []const @ArgType(@typeOf(func), 0), buffer: []@ArgType(@typeOf(func), 0)) []@ArgType(@typeOf(func), 0) {
     // You have to be prepared that the reduce will match all
     assert(buffer.len >= list.len);
@@ -37,6 +42,7 @@ pub fn filter(func: var, list: []const @ArgType(@typeOf(func), 0), buffer: []@Ar
     return buffer[0..count];
 }
 
+// Returns a new array including items only where the filter function returned true
 // You have to free the result
 pub fn filterAlloc(func: var, list: []const @ArgType(@typeOf(func), 0), allocator: &mem.Allocator) ![]@ArgType(@typeOf(func), 0) {
     // We can't know how much to allocate so we will over allocate
@@ -53,6 +59,7 @@ test "functional.filter" {
     assert(mem.eql(i32, try filterAlloc(test_is_even, ([]i32{ 1, 4, 5, 2, 8 })[0..], &direct_allocator.allocator), []i32{ 4, 2, 8 }));
 }
 
+// Reduces all the items in the array to a singular value according the the function
 pub fn reduce(func: var, list: []const @typeOf(func).ReturnType) @typeOf(func).ReturnType {
     var out = list[0];
     for (list[1..]) |item| {


### PR DESCRIPTION
# Motivation
Just felt the library needed this.  It is super simple shouldn't really be too major.

## Side Note
Also kinda shows how Zig needs lambdas of some sort most likely just the ability to declare inline functions like;
```C
var pow = mapAlloc(fn(a: i32)i32 => { a*a; }, list, allocator);
```
Instead of currently requiring you to predeclare that function somewhere else and use it like;
```C
var pow = mapAlloc(pow, list, allocator);
```

## IMPORTANT
To make it easy I've made two commits; if you like the first one then please say and I'll reverse the second commit.  The second commit just doesn't require types however it does make the code a bit more complicated.

FOR EXAMPLE;
The first commit would require; `mapAlloc(i32, i32, add, list, allocator);`
The second just requires; `mapAlloc(add, list, allocator);`.  Now while in most cases I think having explicit types helps, this is all about functional programming so I think requiring to have the types could be quite annoying.

However maybe some nice @compileErrors should popup if you do things really wrong?  But then again it would give you pretty good errors anyway.

Currently for example if your types mismatch it gives;
```
/Users/<USER>/.../<FILE>.zig:<LINE>:<COL>: error: expected type '[]const i32', found '[]bool'
```
That is it looked at my array of integers being passed in and saw that the function returned a boolean and went those don't match!

IF you give a non-function, it'll tell you;
```
/Users/<USER>/.../<FILE>.zig:<LINE>:<COL>: error: expected function, found '(integer literal)'
```
Which is real nice (integer literal cause I used '3' as a testing example).

So I think error wise it probably even gives nicer errors, then again the code is harder to understand due to a lot of builtins everywhere but it is such short snippets maybe that is acceptable?