### PR TITLE
Fixed extern enums having the wrong size

### DIFF
--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -2325,8 +2325,14 @@ static void resolve_enum_zero_bits(CodeGen *g, TypeTableEntry *enum_type) {
     HashMap<BigInt, AstNode *, bigint_hash, bigint_eql> occupied_tag_values = {};
     occupied_tag_values.init(field_count);
 
-    TypeTableEntry *tag_int_type = get_smallest_unsigned_int_type(g, field_count - 1);
+    TypeTableEntry *tag_int_type;
+    if (enum_type->data.enumeration.layout == ContainerLayoutExtern) {
+        tag_int_type = get_c_int_type(g, CIntTypeInt);
+    } else {
+        tag_int_type = get_smallest_unsigned_int_type(g, field_count - 1);
+    }
 
+    // TODO: Are extern enums allowed to have an init_arg_expr?
     if (decl_node->data.container_decl.init_arg_expr != nullptr) {
         TypeTableEntry *wanted_tag_int_type = analyze_type_expr(g, scope, decl_node->data.container_decl.init_arg_expr);
         if (type_is_invalid(wanted_tag_int_type)) {

--- a/test/cases/enum.zig
+++ b/test/cases/enum.zig
@@ -393,11 +393,6 @@ test "enum with 1 field but explicit tag type should still have the tag type" {
     comptime @import("std").debug.assert(@sizeOf(Enum) == @sizeOf(u8));
 }
 
-test "empty extern enum" {
-    const E = extern enum { };
-    assert(@sizeOf(E) == @sizeOf(c_int));
-}
-
 test "empty extern enum with members" {
     const E = extern enum {
         A,

--- a/test/cases/enum.zig
+++ b/test/cases/enum.zig
@@ -392,3 +392,17 @@ test "enum with 1 field but explicit tag type should still have the tag type" {
     const Enum = enum(u8) { B = 2 };
     comptime @import("std").debug.assert(@sizeOf(Enum) == @sizeOf(u8));
 }
+
+test "empty extern enum" {
+    const E = extern enum { };
+    assert(@sizeOf(E) == @sizeOf(c_int));
+}
+
+test "empty extern enum with members" {
+    const E = extern enum {
+        A,
+        B,
+        C,
+    };
+    assert(@sizeOf(E) == @sizeOf(c_int));
+}


### PR DESCRIPTION
For `extern enum`s, `get_smallest_unsigned_int_type` does not give us the tag type that GCC or Clang uses for enums. I've chosen to use `c_int` as a tag type for `extern enum` as it seems to be more in line with what they do, but I'm not sure if that is correct either.

[C Spec](http://www.open-std.org/JTC1/SC22/WG14/www/docs/n1256.pdf):
```
Each enumerated type shall be compatible with char, a signed integer type, or an
unsigned integer type. The choice of type is implementation-defined,110) but shall be
capable of representing the values of all the members of the enumeration. The
enumerated type is incomplete until after the } that terminates the list of enumerator
declarations.
```

It seems that C compilers are allowed to use the smallest size, so how do we handle that when mixing Zig with some niche C compiler that does this?

Also, should specifying the tag type on `extern enum`s be a compiler error?