### PR TITLE
Fixed inlining determination test

### DIFF
--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -142,7 +142,6 @@ static bool ir_should_inline(IrExecutable *exec, Scope *scope) {
     if (exec->is_inline)
         return true;
 
-    // Look at parent scopes until we find a function scope or a comptime scope.
     while (scope != nullptr) {
         if (scope->id == ScopeIdCompTime)
             return true;

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -142,9 +142,12 @@ static bool ir_should_inline(IrExecutable *exec, Scope *scope) {
     if (exec->is_inline)
         return true;
 
+    // Look at parent scopes until we find a function scope or a comptime scope.
     while (scope != nullptr) {
         if (scope->id == ScopeIdCompTime)
             return true;
+        if (scope->id == ScopeIdFnDef)
+            break;
         scope = scope->parent;
     }
     return false;

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -52,4 +52,5 @@ comptime {
     _ = @import("cases/var_args.zig");
     _ = @import("cases/void.zig");
     _ = @import("cases/while.zig");
+    _ = @import("cases/fn_in_struct_in_comptime.zig");
 }

--- a/test/cases/fn_in_struct_in_comptime.zig
+++ b/test/cases/fn_in_struct_in_comptime.zig
@@ -1,0 +1,17 @@
+const assert = @import("std").debug.assert;
+
+fn get_foo() fn(&u8)usize {
+    comptime {
+        return struct {
+            fn func(ptr: &u8) usize {
+                var u = @ptrToInt(ptr);
+                return u;
+            }
+        }.func;
+    }
+}
+
+test "define a function in an anonymous struct in comptime" {
+    const foo = get_foo();
+    assert(foo(@intToPtr(&u8, 12345)) == 12345);
+}


### PR DESCRIPTION
In addition to looking up the scopes until we find a comptime scope to determine whether we should inline, we should break at a function definition scope.  

Closes #971.