### PR TITLE
ArrayList iterator, unifying API of HashMap and its derivatives

### DIFF
--- a/std/buf_map.zig
+++ b/std/buf_map.zig
@@ -50,7 +50,7 @@ pub const BufMap = struct {
     }
 
     pub fn count(self: &const BufMap) usize {
-        return self.hash_map.size;
+        return self.hash_map.count();
     }
 
     pub fn iterator(self: &const BufMap) BufMapHashMap.Iterator {

--- a/std/buf_set.zig
+++ b/std/buf_set.zig
@@ -38,7 +38,7 @@ pub const BufSet = struct {
     }
 
     pub fn count(self: &const BufSet) usize {
-        return self.hash_map.size;
+        return self.hash_map.count();
     }
 
     pub fn iterator(self: &const BufSet) BufSetHashMap.Iterator {
@@ -59,4 +59,3 @@ pub const BufSet = struct {
         return result;
     }
 };
-


### PR DESCRIPTION
This PR just does a small little unification; adding 'count' function to hashmap, arraylist, bufmap, and bufset (which just returns the inner storage value), this is more intended for as we extend the amount of data structures it is nice to have a set of API functions to follow for example having a 'count' function and so on, this makes it easier for library builders to utilise duck typing and support multiple collections in their libraries 😄.

Secondly it adds an iterator to ArrayList, again for the above reason.  All iterators also have a reset function attached.

## Motivation

Again to bring up my Lazy library, I support you doing queries on slices such as `Lazy.init(slice[0..]).where(odd).select(pow).toArray(buf[0..])`, and when I wanted to extend it to supporting ArrayLists and Hashmaps I found a problem, they had conflicting APIs (and ArrayList had no iterator), so overall this fixes that by providing a consistent API.