### PR TITLE
Add clang-tidy run on zig sources, minor CMake improvements

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,26 @@
+Checks:          'clang-diagnostic-*,clang-analyzer-*'
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+AnalyzeTemporaryDtors: false
+FormatStyle:     none
+CheckOptions:
+  - key:             google-readability-braces-around-statements.ShortStatementLines
+    value:           '1'
+  - key:             google-readability-function-size.StatementThreshold
+    value:           '800'
+  - key:             google-readability-namespace-comments.ShortNamespaceLines
+    value:           '10'
+  - key:             google-readability-namespace-comments.SpacesBeforeComments
+    value:           '2'
+  - key:             modernize-loop-convert.MaxCopySize
+    value:           '16'
+  - key:             modernize-loop-convert.MinConfidence
+    value:           reasonable
+  - key:             modernize-loop-convert.NamingStyle
+    value:           CamelCase
+  - key:             modernize-pass-by-value.IncludeStyle
+    value:           llvm
+  - key:             modernize-replace-auto-ptr.IncludeStyle
+    value:           llvm
+  - key:             modernize-use-nullptr.NullMacros
+    value:           'NULL'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,4 @@
-Checks:          'clang-diagnostic-*,clang-analyzer-*'
+Checks:          'clang-diagnostic-*,clang-analyzer-*,-clang-analyzer-unix.Malloc,-clang-analyzer-cplusplus.NewDeleteLeaks'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -762,7 +762,7 @@ set_target_properties(zig PROPERTIES
     LINK_FLAGS ${EXE_LDFLAGS}
 )
 
-if(ENABLED_CLANG_TIDY)
+if(ENABLE_CLANG_TIDY)
     set_target_properties(zig_cpp PROPERTIES
         C_CLANG_TIDY ${CLANG_TIDY_PATH}
         CXX_CLANG_TIDY ${CLANG_TIDY_PATH})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.5)
+cmake_minimum_required(VERSION 3.1)
 
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Debug" CACHE STRING
@@ -6,18 +6,26 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 
 if(NOT CMAKE_INSTALL_PREFIX)
-  set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}" CACHE STRING
+  set(CMAKE_INSTALL_PREFIX "${CMAKE_CURRENT_BINARY_DIR}" CACHE STRING
       "Directory to install zig to" FORCE)
 endif()
 
-project(zig C CXX)
-set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
+option(CMAKE_EXPORT_COMPILE_COMMANDS "Generate compilation database" ON)
 
+include(CMakeDependentOption)
+find_program(CLANG_TIDY_PATH clang-tidy)
+cmake_dependent_option(
+    ENABLE_CLANG_TIDY "Run clang-tidy on zig sources" ON
+    "CLANG_TIDY_PATH" OFF)
+
+set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 
 set(ZIG_VERSION_MAJOR 0)
 set(ZIG_VERSION_MINOR 2)
 set(ZIG_VERSION_PATCH 0)
 set(ZIG_VERSION "${ZIG_VERSION_MAJOR}.${ZIG_VERSION_MINOR}.${ZIG_VERSION_PATCH}")
+
+project(zig LANGUAGES C CXX VERSION "${ZIG_VERSION}")
 
 find_program(GIT_EXE NAMES git)
 if(GIT_EXE)
@@ -66,7 +74,7 @@ if(NOT MSVC)
     endif()
 endif()
 
-set(ZIG_CPP_LIB_DIR "${CMAKE_BINARY_DIR}/zig_cpp")
+set(ZIG_CPP_LIB_DIR "${CMAKE_CURRENT_BINARY_DIR}/zig_cpp")
 
 if(ZIG_FORCE_EXTERNAL_LLD)
     find_package(lld)
@@ -76,117 +84,117 @@ if(ZIG_FORCE_EXTERNAL_LLD)
 else()
     # This goes first so that we find embedded LLD instead
     # of system LLD.
-    include_directories("${CMAKE_SOURCE_DIR}/deps/lld/include")
+    include_directories("${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/include")
 
     include_directories(${LLVM_INCLUDE_DIRS})
     include_directories(${CLANG_INCLUDE_DIRS})
     set(EMBEDDED_LLD_LIB_SOURCES
-        "${CMAKE_SOURCE_DIR}/deps/lld/Common/Args.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/Common/ErrorHandler.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/Common/Memory.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/Common/Reproduce.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/Common/Strings.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/Common/TargetOptionsCommandFlags.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/Common/Threads.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/Common/Version.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/lib/Core/DefinedAtom.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/lib/Core/Error.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/lib/Core/File.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/lib/Core/LinkingContext.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/lib/Core/Reader.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/lib/Core/Resolver.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/lib/Core/SymbolTable.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/lib/Core/Writer.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/lib/Driver/DarwinLdDriver.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/lib/ReaderWriter/FileArchive.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/lib/ReaderWriter/MachO/ArchHandler.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/lib/ReaderWriter/MachO/ArchHandler_arm.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/lib/ReaderWriter/MachO/ArchHandler_arm64.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/lib/ReaderWriter/MachO/ArchHandler_x86.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/lib/ReaderWriter/MachO/ArchHandler_x86_64.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/lib/ReaderWriter/MachO/CompactUnwindPass.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/lib/ReaderWriter/MachO/GOTPass.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/lib/ReaderWriter/MachO/LayoutPass.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/lib/ReaderWriter/MachO/MachOLinkingContext.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/lib/ReaderWriter/MachO/MachONormalizedFileBinaryReader.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/lib/ReaderWriter/MachO/MachONormalizedFileBinaryWriter.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/lib/ReaderWriter/MachO/MachONormalizedFileFromAtoms.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/lib/ReaderWriter/MachO/MachONormalizedFileToAtoms.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/lib/ReaderWriter/MachO/MachONormalizedFileYAML.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/lib/ReaderWriter/MachO/ObjCPass.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/lib/ReaderWriter/MachO/ShimPass.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/lib/ReaderWriter/MachO/StubsPass.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/lib/ReaderWriter/MachO/TLVPass.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/lib/ReaderWriter/MachO/WriterMachO.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/lib/ReaderWriter/YAML/ReaderWriterYAML.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/Common/Args.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/Common/ErrorHandler.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/Common/Memory.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/Common/Reproduce.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/Common/Strings.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/Common/TargetOptionsCommandFlags.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/Common/Threads.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/Common/Version.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/lib/Core/DefinedAtom.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/lib/Core/Error.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/lib/Core/File.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/lib/Core/LinkingContext.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/lib/Core/Reader.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/lib/Core/Resolver.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/lib/Core/SymbolTable.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/lib/Core/Writer.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/lib/Driver/DarwinLdDriver.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/lib/ReaderWriter/FileArchive.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/lib/ReaderWriter/MachO/ArchHandler.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/lib/ReaderWriter/MachO/ArchHandler_arm.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/lib/ReaderWriter/MachO/ArchHandler_arm64.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/lib/ReaderWriter/MachO/ArchHandler_x86.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/lib/ReaderWriter/MachO/ArchHandler_x86_64.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/lib/ReaderWriter/MachO/CompactUnwindPass.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/lib/ReaderWriter/MachO/GOTPass.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/lib/ReaderWriter/MachO/LayoutPass.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/lib/ReaderWriter/MachO/MachOLinkingContext.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/lib/ReaderWriter/MachO/MachONormalizedFileBinaryReader.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/lib/ReaderWriter/MachO/MachONormalizedFileBinaryWriter.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/lib/ReaderWriter/MachO/MachONormalizedFileFromAtoms.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/lib/ReaderWriter/MachO/MachONormalizedFileToAtoms.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/lib/ReaderWriter/MachO/MachONormalizedFileYAML.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/lib/ReaderWriter/MachO/ObjCPass.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/lib/ReaderWriter/MachO/ShimPass.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/lib/ReaderWriter/MachO/StubsPass.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/lib/ReaderWriter/MachO/TLVPass.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/lib/ReaderWriter/MachO/WriterMachO.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/lib/ReaderWriter/YAML/ReaderWriterYAML.cpp"
     )
     set(EMBEDDED_LLD_ELF_SOURCES
-        "${CMAKE_SOURCE_DIR}/deps/lld/ELF/AArch64ErrataFix.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/ELF/Arch/AArch64.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/ELF/Arch/AMDGPU.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/ELF/Arch/ARM.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/ELF/Arch/AVR.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/ELF/Arch/Mips.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/ELF/Arch/MipsArchTree.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/ELF/Arch/PPC.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/ELF/Arch/PPC64.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/ELF/Arch/SPARCV9.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/ELF/Arch/X86.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/ELF/Arch/X86_64.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/ELF/Driver.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/ELF/DriverUtils.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/ELF/EhFrame.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/ELF/Filesystem.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/ELF/GdbIndex.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/ELF/ICF.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/ELF/InputFiles.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/ELF/InputSection.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/ELF/LTO.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/ELF/LinkerScript.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/ELF/MapFile.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/ELF/MarkLive.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/ELF/OutputSections.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/ELF/Relocations.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/ELF/ScriptLexer.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/ELF/ScriptParser.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/ELF/Strings.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/ELF/SymbolTable.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/ELF/Symbols.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/ELF/SyntheticSections.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/ELF/Target.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/ELF/Thunks.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/ELF/Writer.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/ELF/AArch64ErrataFix.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/ELF/Arch/AArch64.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/ELF/Arch/AMDGPU.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/ELF/Arch/ARM.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/ELF/Arch/AVR.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/ELF/Arch/Mips.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/ELF/Arch/MipsArchTree.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/ELF/Arch/PPC.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/ELF/Arch/PPC64.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/ELF/Arch/SPARCV9.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/ELF/Arch/X86.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/ELF/Arch/X86_64.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/ELF/Driver.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/ELF/DriverUtils.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/ELF/EhFrame.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/ELF/Filesystem.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/ELF/GdbIndex.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/ELF/ICF.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/ELF/InputFiles.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/ELF/InputSection.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/ELF/LTO.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/ELF/LinkerScript.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/ELF/MapFile.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/ELF/MarkLive.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/ELF/OutputSections.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/ELF/Relocations.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/ELF/ScriptLexer.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/ELF/ScriptParser.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/ELF/Strings.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/ELF/SymbolTable.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/ELF/Symbols.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/ELF/SyntheticSections.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/ELF/Target.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/ELF/Thunks.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/ELF/Writer.cpp"
     )
 
     set(EMBEDDED_LLD_COFF_SOURCES
-        "${CMAKE_SOURCE_DIR}/deps/lld/COFF/Chunks.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/COFF/DLL.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/COFF/Driver.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/COFF/DriverUtils.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/COFF/ICF.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/COFF/InputFiles.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/COFF/LTO.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/COFF/MapFile.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/COFF/MarkLive.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/COFF/MinGW.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/COFF/PDB.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/COFF/Strings.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/COFF/SymbolTable.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/COFF/Symbols.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/COFF/Writer.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/COFF/Chunks.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/COFF/DLL.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/COFF/Driver.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/COFF/DriverUtils.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/COFF/ICF.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/COFF/InputFiles.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/COFF/LTO.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/COFF/MapFile.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/COFF/MarkLive.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/COFF/MinGW.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/COFF/PDB.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/COFF/Strings.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/COFF/SymbolTable.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/COFF/Symbols.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/COFF/Writer.cpp"
     )
     set(EMBEDDED_LLD_MINGW_SOURCES
-        "${CMAKE_SOURCE_DIR}/deps/lld/MinGW/Driver.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/MinGW/Driver.cpp"
     )
     set(EMBEDDED_LLD_WASM_SOURCES
-        "${CMAKE_SOURCE_DIR}/deps/lld/wasm/Driver.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/wasm/InputFiles.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/wasm/InputSegment.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/wasm/OutputSections.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/wasm/Symbols.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/wasm/SymbolTable.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/wasm/Writer.cpp"
-        "${CMAKE_SOURCE_DIR}/deps/lld/wasm/WriterUtils.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/wasm/Driver.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/wasm/InputFiles.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/wasm/InputSegment.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/wasm/OutputSections.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/wasm/Symbols.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/wasm/SymbolTable.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/wasm/Writer.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/wasm/WriterUtils.cpp"
     )
     add_library(embedded_lld_lib ${EMBEDDED_LLD_LIB_SOURCES})
     add_library(embedded_lld_elf ${EMBEDDED_LLD_ELF_SOURCES})
@@ -219,32 +227,32 @@ else()
         LINK_FLAGS " "
     )
     target_include_directories(embedded_lld_lib PRIVATE
-        "${CMAKE_SOURCE_DIR}/deps/lld/include"
-        "${CMAKE_SOURCE_DIR}/deps/lld-prebuilt"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/include"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld-prebuilt"
     )
     target_include_directories(embedded_lld_elf PRIVATE
-        "${CMAKE_SOURCE_DIR}/deps/lld/ELF"
-        "${CMAKE_SOURCE_DIR}/deps/lld/include"
-        "${CMAKE_SOURCE_DIR}/deps/lld-prebuilt/ELF"
-        "${CMAKE_SOURCE_DIR}/deps/lld-prebuilt"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/ELF"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/include"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld-prebuilt/ELF"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld-prebuilt"
     )
     target_include_directories(embedded_lld_coff PRIVATE
-        "${CMAKE_SOURCE_DIR}/deps/lld/COFF"
-        "${CMAKE_SOURCE_DIR}/deps/lld/include"
-        "${CMAKE_SOURCE_DIR}/deps/lld-prebuilt/COFF"
-        "${CMAKE_SOURCE_DIR}/deps/lld-prebuilt"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/COFF"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/include"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld-prebuilt/COFF"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld-prebuilt"
     )
     target_include_directories(embedded_lld_mingw PRIVATE
-        "${CMAKE_SOURCE_DIR}/deps/lld/MinGW"
-        "${CMAKE_SOURCE_DIR}/deps/lld/include"
-        "${CMAKE_SOURCE_DIR}/deps/lld-prebuilt/MinGW"
-        "${CMAKE_SOURCE_DIR}/deps/lld-prebuilt"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/MinGW"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/include"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld-prebuilt/MinGW"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld-prebuilt"
     )
     target_include_directories(embedded_lld_wasm PRIVATE
-        "${CMAKE_SOURCE_DIR}/deps/lld/wasm"
-        "${CMAKE_SOURCE_DIR}/deps/lld/include"
-        "${CMAKE_SOURCE_DIR}/deps/lld-prebuilt/wasm"
-        "${CMAKE_SOURCE_DIR}/deps/lld-prebuilt"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/wasm"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld/include"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld-prebuilt/wasm"
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/lld-prebuilt"
     )
     set(LLD_INCLUDE_DIRS "")
     set(LLD_LIBRARIES
@@ -259,114 +267,114 @@ endif()
 
 # No patches have been applied to SoftFloat-3e
 set(EMBEDDED_SOFTFLOAT_SOURCES
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/8086/f128M_isSignalingNaN.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/8086/s_commonNaNToF128M.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/8086/s_commonNaNToF32UI.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/8086/s_commonNaNToF64UI.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/8086/s_f128MToCommonNaN.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/8086/s_f32UIToCommonNaN.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/8086/s_f64UIToCommonNaN.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/8086/s_propagateNaNF128M.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/8086/softfloat_raiseFlags.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/f128M_add.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/f128M_div.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/f128M_eq.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/f128M_eq_signaling.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/f128M_le.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/f128M_le_quiet.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/f128M_lt.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/f128M_lt_quiet.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/f128M_mul.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/f128M_mulAdd.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/f128M_rem.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/f128M_roundToInt.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/f128M_sqrt.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/f128M_sub.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/f128M_to_f16.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/f128M_to_f32.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/f128M_to_f64.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/f128M_to_i32.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/f128M_to_i32_r_minMag.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/f128M_to_i64.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/f128M_to_i64_r_minMag.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/f128M_to_ui32.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/f128M_to_ui32_r_minMag.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/f128M_to_ui64.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/f128M_to_ui64_r_minMag.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/f32_to_f128M.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/f64_to_f128M.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_add256M.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_addCarryM.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_addComplCarryM.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_addF128M.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_addM.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_addMagsF16.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_addMagsF32.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_addMagsF64.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_approxRecip32_1.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_approxRecipSqrt32_1.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_approxRecipSqrt_1Ks.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_approxRecip_1Ks.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_compare128M.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_compare96M.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_countLeadingZeros16.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_countLeadingZeros32.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_countLeadingZeros64.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_countLeadingZeros8.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_eq128.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_invalidF128M.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_isNaNF128M.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_le128.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_lt128.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_mul128MTo256M.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_mul64To128M.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_mulAddF128M.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_mulAddF16.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_mulAddF32.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_mulAddF64.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_negXM.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_normRoundPackMToF128M.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_normRoundPackToF16.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_normRoundPackToF32.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_normRoundPackToF64.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_normSubnormalF128SigM.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_normSubnormalF16Sig.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_normSubnormalF32Sig.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_normSubnormalF64Sig.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_remStepMBy32.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_roundMToI64.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_roundMToUI64.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_roundPackMToF128M.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_roundPackToF16.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_roundPackToF32.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_roundPackToF64.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_roundToI32.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_roundToI64.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_roundToUI32.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_roundToUI64.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_shiftLeftM.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_shiftNormSigF128M.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_shiftRightJam256M.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_shiftRightJam32.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_shiftRightJam64.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_shiftRightJamM.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_shiftRightM.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_shortShiftLeft64To96M.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_shortShiftLeftM.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_shortShiftRightExtendM.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_shortShiftRightJam64.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_shortShiftRightJamM.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_shortShiftRightM.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_sub1XM.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_sub256M.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_subM.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_subMagsF16.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_subMagsF32.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_subMagsF64.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/s_tryPropagateNaNF128M.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/softfloat_state.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/ui32_to_f128M.c"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/ui64_to_f128M.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/8086/f128M_isSignalingNaN.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/8086/s_commonNaNToF128M.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/8086/s_commonNaNToF32UI.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/8086/s_commonNaNToF64UI.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/8086/s_f128MToCommonNaN.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/8086/s_f32UIToCommonNaN.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/8086/s_f64UIToCommonNaN.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/8086/s_propagateNaNF128M.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/8086/softfloat_raiseFlags.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/f128M_add.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/f128M_div.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/f128M_eq.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/f128M_eq_signaling.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/f128M_le.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/f128M_le_quiet.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/f128M_lt.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/f128M_lt_quiet.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/f128M_mul.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/f128M_mulAdd.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/f128M_rem.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/f128M_roundToInt.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/f128M_sqrt.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/f128M_sub.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/f128M_to_f16.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/f128M_to_f32.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/f128M_to_f64.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/f128M_to_i32.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/f128M_to_i32_r_minMag.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/f128M_to_i64.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/f128M_to_i64_r_minMag.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/f128M_to_ui32.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/f128M_to_ui32_r_minMag.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/f128M_to_ui64.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/f128M_to_ui64_r_minMag.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/f32_to_f128M.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/f64_to_f128M.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_add256M.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_addCarryM.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_addComplCarryM.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_addF128M.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_addM.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_addMagsF16.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_addMagsF32.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_addMagsF64.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_approxRecip32_1.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_approxRecipSqrt32_1.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_approxRecipSqrt_1Ks.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_approxRecip_1Ks.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_compare128M.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_compare96M.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_countLeadingZeros16.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_countLeadingZeros32.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_countLeadingZeros64.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_countLeadingZeros8.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_eq128.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_invalidF128M.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_isNaNF128M.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_le128.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_lt128.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_mul128MTo256M.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_mul64To128M.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_mulAddF128M.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_mulAddF16.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_mulAddF32.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_mulAddF64.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_negXM.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_normRoundPackMToF128M.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_normRoundPackToF16.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_normRoundPackToF32.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_normRoundPackToF64.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_normSubnormalF128SigM.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_normSubnormalF16Sig.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_normSubnormalF32Sig.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_normSubnormalF64Sig.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_remStepMBy32.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_roundMToI64.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_roundMToUI64.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_roundPackMToF128M.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_roundPackToF16.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_roundPackToF32.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_roundPackToF64.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_roundToI32.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_roundToI64.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_roundToUI32.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_roundToUI64.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_shiftLeftM.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_shiftNormSigF128M.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_shiftRightJam256M.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_shiftRightJam32.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_shiftRightJam64.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_shiftRightJamM.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_shiftRightM.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_shortShiftLeft64To96M.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_shortShiftLeftM.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_shortShiftRightExtendM.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_shortShiftRightJam64.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_shortShiftRightJamM.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_shortShiftRightM.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_sub1XM.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_sub256M.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_subM.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_subMagsF16.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_subMagsF32.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_subMagsF64.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/s_tryPropagateNaNF128M.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/softfloat_state.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/ui32_to_f128M.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/ui64_to_f128M.c"
 )
 add_library(embedded_softfloat ${EMBEDDED_SOFTFLOAT_SOURCES})
 if(MSVC)
@@ -379,38 +387,38 @@ else()
     )
 endif()
 target_include_directories(embedded_softfloat PUBLIC
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e-prebuilt"
-    "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/8086"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e-prebuilt"
+    "${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/8086"
 )
-include_directories("${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/include")
+include_directories("${CMAKE_CURRENT_SOURCE_DIR}/deps/SoftFloat-3e/source/include")
 set(SOFTFLOAT_LIBRARIES embedded_softfloat)
 
 find_package(Threads)
 
 set(ZIG_SOURCES
-    "${CMAKE_SOURCE_DIR}/src/analyze.cpp"
-    "${CMAKE_SOURCE_DIR}/src/ast_render.cpp"
-    "${CMAKE_SOURCE_DIR}/src/bigfloat.cpp"
-    "${CMAKE_SOURCE_DIR}/src/bigint.cpp"
-    "${CMAKE_SOURCE_DIR}/src/buffer.cpp"
-    "${CMAKE_SOURCE_DIR}/src/c_tokenizer.cpp"
-    "${CMAKE_SOURCE_DIR}/src/codegen.cpp"
-    "${CMAKE_SOURCE_DIR}/src/errmsg.cpp"
-    "${CMAKE_SOURCE_DIR}/src/error.cpp"
-    "${CMAKE_SOURCE_DIR}/src/ir.cpp"
-    "${CMAKE_SOURCE_DIR}/src/ir_print.cpp"
-    "${CMAKE_SOURCE_DIR}/src/link.cpp"
-    "${CMAKE_SOURCE_DIR}/src/main.cpp"
-    "${CMAKE_SOURCE_DIR}/src/os.cpp"
-    "${CMAKE_SOURCE_DIR}/src/parser.cpp"
-    "${CMAKE_SOURCE_DIR}/src/range_set.cpp"
-    "${CMAKE_SOURCE_DIR}/src/target.cpp"
-    "${CMAKE_SOURCE_DIR}/src/tokenizer.cpp"
-    "${CMAKE_SOURCE_DIR}/src/util.cpp"
-    "${CMAKE_SOURCE_DIR}/src/translate_c.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/analyze.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/ast_render.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/bigfloat.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/bigint.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/buffer.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/c_tokenizer.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/codegen.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/errmsg.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/error.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/ir.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/ir_print.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/link.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/os.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/parser.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/range_set.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/target.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/tokenizer.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/util.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/translate_c.cpp"
 )
 set(ZIG_CPP_SOURCES
-    "${CMAKE_SOURCE_DIR}/src/zig_llvm.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/zig_llvm.cpp"
 )
 
 set(ZIG_STD_FILES
@@ -702,16 +710,16 @@ endif()
 set(ZIG_LIB_DIR "lib/zig")
 set(C_HEADERS_DEST "${ZIG_LIB_DIR}/include")
 set(ZIG_STD_DEST "${ZIG_LIB_DIR}/std")
-set(CONFIGURE_OUT_FILE "${CMAKE_BINARY_DIR}/config.h")
+set(CONFIGURE_OUT_FILE "${CMAKE_CURRENT_BINARY_DIR}/config.h")
 configure_file (
-    "${CMAKE_SOURCE_DIR}/src/config.h.in"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/config.h.in"
     ${CONFIGURE_OUT_FILE}
 )
 
 include_directories(
-    ${CMAKE_SOURCE_DIR}
-    ${CMAKE_BINARY_DIR}
-    "${CMAKE_SOURCE_DIR}/src"
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_BINARY_DIR}
+    "${CMAKE_CURRENT_SOURCE_DIR}/src"
 )
 
 if(MSVC)
@@ -754,13 +762,23 @@ set_target_properties(zig PROPERTIES
     LINK_FLAGS ${EXE_LDFLAGS}
 )
 
+if(ENABLED_CLANG_TIDY)
+    set_target_properties(zig_cpp PROPERTIES
+        C_CLANG_TIDY ${CLANG_TIDY_PATH}
+        CXX_CLANG_TIDY ${CLANG_TIDY_PATH})
+    set_target_properties(zig PROPERTIES
+        C_CLANG_TIDY ${CLANG_TIDY_PATH}
+        CXX_CLANG_TIDY ${CLANG_TIDY_PATH})
+endif()
+
+find_library(Threads REQUIRED)
 target_link_libraries(zig LINK_PUBLIC
     zig_cpp
     ${SOFTFLOAT_LIBRARIES}
     ${CLANG_LIBRARIES}
     ${LLD_LIBRARIES}
     ${LLVM_LIBRARIES}
-    ${CMAKE_THREAD_LIBS_INIT}
+    Threads::Threads
 )
 if(NOT MSVC)
     target_link_libraries(zig LINK_PUBLIC ${LIBXML2})
@@ -777,10 +795,10 @@ install(TARGETS zig_cpp DESTINATION "${ZIG_CPP_LIB_DIR}")
 
 foreach(file ${ZIG_C_HEADER_FILES})
     get_filename_component(file_dir "${C_HEADERS_DEST}/${file}" DIRECTORY)
-    install(FILES "${CMAKE_SOURCE_DIR}/c_headers/${file}" DESTINATION "${file_dir}")
+    install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/c_headers/${file}" DESTINATION "${file_dir}")
 endforeach()
 
 foreach(file ${ZIG_STD_FILES})
     get_filename_component(file_dir "${ZIG_STD_DEST}/${file}" DIRECTORY)
-    install(FILES "${CMAKE_SOURCE_DIR}/std/${file}" DESTINATION "${file_dir}")
+    install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/std/${file}" DESTINATION "${file_dir}")
 endforeach()

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ libc. Create demo games using Zig.
 
 ##### POSIX
 
- * cmake >= 2.8.5
+ * cmake >= 3.1
  * gcc >= 5.0.0 or clang >= 3.6.0
  * LLVM, Clang, LLD development libraries == 6.x, compiled with the same gcc or clang version above
    - These depend on zlib and libxml2.

--- a/ci/travis_linux_install
+++ b/ci/travis_linux_install
@@ -4,4 +4,4 @@ set -x
 
 sudo apt-get remove -y llvm-*
 sudo rm -rf /usr/local/*
-sudo apt-get install -y clang-6.0 libclang-6.0 libclang-6.0-dev llvm-6.0 llvm-6.0-dev liblld-6.0 liblld-6.0-dev cmake wine1.6-amd64 s3cmd
+sudo apt-get install -y clang-6.0 libclang-6.0 libclang-6.0-dev llvm-6.0 llvm-6.0-dev liblld-6.0 liblld-6.0-dev cmake3 wine1.6-amd64 s3cmd

--- a/ci/travis_osx_install
+++ b/ci/travis_osx_install
@@ -2,6 +2,7 @@
 
 set -x
 
-brew install llvm@6
-brew outdated llvm@6 || brew upgrade llvm@6
-
+for pkg in llvm@6 cmake; do
+    brew install "$pkg"
+    brew outdated "$pkg" || brew upgrade "$pkg"
+done

--- a/ci/travis_osx_install
+++ b/ci/travis_osx_install
@@ -2,7 +2,6 @@
 
 set -x
 
-for pkg in llvm@6 cmake; do
-    brew install "$pkg"
-    brew outdated "$pkg" || brew upgrade "$pkg"
-done
+brew install llvm@6
+brew outdated llvm@6 || brew upgrade llvm@6
+

--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -27,6 +27,9 @@ static void resolve_enum_zero_bits(CodeGen *g, TypeTableEntry *enum_type);
 static void resolve_union_zero_bits(CodeGen *g, TypeTableEntry *union_type);
 
 ErrorMsg *add_node_error(CodeGen *g, AstNode *node, Buf *msg) {
+    assert(node != nullptr);
+    assert(node->owner != nullptr);
+
     if (node->owner->c_import_node != nullptr) {
         // if this happens, then translate_c generated code that
         // failed semantic analysis, which isn't supposed to happen
@@ -4236,6 +4239,7 @@ TypeTableEntry **get_int_type_ptr(CodeGen *g, bool is_signed, uint32_t size_in_b
 }
 
 TypeTableEntry *get_int_type(CodeGen *g, bool is_signed, uint32_t size_in_bits) {
+    assert(g != nullptr);
     TypeTableEntry **common_entry = get_int_type_ptr(g, is_signed, size_in_bits);
     if (common_entry)
         return *common_entry;

--- a/src/buffer.hpp
+++ b/src/buffer.hpp
@@ -33,6 +33,7 @@ static inline size_t buf_len(Buf *buf) {
 }
 
 static inline char *buf_ptr(Buf *buf) {
+    assert(buf != nullptr);
     assert(buf->list.length);
     return buf->list.items;
 }
@@ -119,6 +120,7 @@ static inline void buf_append_buf(Buf *buf, Buf *append_buf) {
 }
 
 static inline void buf_append_char(Buf *buf, uint8_t c) {
+    assert(buf != nullptr);
     assert(buf->list.length);
     buf_append_mem(buf, (const char *)&c, 1);
 }

--- a/src/c_tokenizer.cpp
+++ b/src/c_tokenizer.cpp
@@ -756,7 +756,6 @@ void tokenize_c_macro(CTokenize *ctok, const uint8_t *c) {
                 }
                 break;
             case CTokStateComment:
-                assert(ctok->cur_tok != nullptr);
                 switch (*c) {
                     case '*':
                         ctok->state = CTokStateCommentStar;
@@ -766,7 +765,6 @@ void tokenize_c_macro(CTokenize *ctok, const uint8_t *c) {
                 }
                 break;
             case CTokStateCommentStar:
-                assert(ctok->cur_tok != nullptr);
                 switch (*c) {
                     case '/':
                         ctok->state = CTokStateStart;
@@ -779,7 +777,6 @@ void tokenize_c_macro(CTokenize *ctok, const uint8_t *c) {
                 }
                 break;
             case CTokStateBackslash:
-                assert(ctok->cur_tok != nullptr);
                 switch (*c) {
                     case '\n':
                         ctok->state = CTokStateStart;

--- a/src/c_tokenizer.cpp
+++ b/src/c_tokenizer.cpp
@@ -252,6 +252,7 @@ void tokenize_c_macro(CTokenize *ctok, const uint8_t *c) {
                 }
                 break;
             case CTokStateFloat:
+                assert(ctok->cur_tok != nullptr);
                 switch (*c) {
                     case '.':
                         break;
@@ -276,6 +277,7 @@ void tokenize_c_macro(CTokenize *ctok, const uint8_t *c) {
                 }
                 break;
             case CTokStateExpSign:
+                assert(ctok->cur_tok != nullptr);
                 switch (*c) {
                     case '+':
                     case '-':
@@ -291,6 +293,7 @@ void tokenize_c_macro(CTokenize *ctok, const uint8_t *c) {
                 }
                 break;
             case CTokStateFloatExpFirst:
+                assert(ctok->cur_tok != nullptr);
                 switch (*c) {
                     case DIGIT:
                         buf_append_char(&ctok->buf, *c);
@@ -301,6 +304,7 @@ void tokenize_c_macro(CTokenize *ctok, const uint8_t *c) {
                 }
                 break;
             case CTokStateFloatExp:
+                assert(ctok->cur_tok != nullptr);
                 switch (*c) {
                     case DIGIT:
                         buf_append_char(&ctok->buf, *c);
@@ -318,6 +322,7 @@ void tokenize_c_macro(CTokenize *ctok, const uint8_t *c) {
                 }
                 break;
             case CTokStateDecimal:
+                assert(ctok->cur_tok != nullptr);
                 switch (*c) {
                     case DIGIT:
                         buf_append_char(&ctok->buf, *c);
@@ -352,6 +357,7 @@ void tokenize_c_macro(CTokenize *ctok, const uint8_t *c) {
                 }
                 break;
             case CTokStateGotZero:
+                assert(ctok->cur_tok != nullptr);
                 switch (*c) {
                     case 'x':
                     case 'X':
@@ -369,6 +375,7 @@ void tokenize_c_macro(CTokenize *ctok, const uint8_t *c) {
                 }
                 break;
             case CTokStateOctal:
+                assert(ctok->cur_tok != nullptr);
                 switch (*c) {
                     case '0':
                     case '1':
@@ -396,6 +403,7 @@ void tokenize_c_macro(CTokenize *ctok, const uint8_t *c) {
                 }
                 break;
             case CTokStateHex:
+                assert(ctok->cur_tok != nullptr);
                 switch (*c) {
                     case '0':
                         hex_digit(ctok, 0);
@@ -476,6 +484,7 @@ void tokenize_c_macro(CTokenize *ctok, const uint8_t *c) {
                 }
                 break;
             case CTokStateNumLitIntSuffixU:
+                assert(ctok->cur_tok != nullptr);
                 switch (*c) {
                     case 'l':
                     case 'L':
@@ -490,6 +499,7 @@ void tokenize_c_macro(CTokenize *ctok, const uint8_t *c) {
                 }
                 break;
             case CTokStateNumLitIntSuffixL:
+                assert(ctok->cur_tok != nullptr);
                 switch (*c) {
                     case 'l':
                     case 'L':
@@ -510,6 +520,7 @@ void tokenize_c_macro(CTokenize *ctok, const uint8_t *c) {
                 }
                 break;
             case CTokStateNumLitIntSuffixLL:
+                assert(ctok->cur_tok != nullptr);
                 switch (*c) {
                     case 'u':
                     case 'U':
@@ -525,6 +536,7 @@ void tokenize_c_macro(CTokenize *ctok, const uint8_t *c) {
                 }
                 break;
             case CTokStateNumLitIntSuffixUL:
+                assert(ctok->cur_tok != nullptr);
                 switch (*c) {
                     case 'l':
                     case 'L':
@@ -540,6 +552,7 @@ void tokenize_c_macro(CTokenize *ctok, const uint8_t *c) {
                 }
                 break;
             case CTokStateIdentifier:
+                assert(ctok->cur_tok != nullptr);
                 switch (*c) {
                     case IDENT:
                         buf_append_char(&ctok->cur_tok->data.symbol, *c);
@@ -552,6 +565,7 @@ void tokenize_c_macro(CTokenize *ctok, const uint8_t *c) {
                 }
                 break;
             case CTokStateString:
+                assert(ctok->cur_tok != nullptr);
                 switch (*c) {
                     case '\\':
                         ctok->state = CTokStateCharEscape;
@@ -565,6 +579,7 @@ void tokenize_c_macro(CTokenize *ctok, const uint8_t *c) {
                 }
                 break;
             case CTokStateExpectChar:
+                assert(ctok->cur_tok != nullptr);
                 switch (*c) {
                     case '\\':
                         ctok->state = CTokStateCharEscape;
@@ -577,6 +592,7 @@ void tokenize_c_macro(CTokenize *ctok, const uint8_t *c) {
                 }
                 break;
             case CTokStateCharEscape:
+                assert(ctok->cur_tok != nullptr);
                 switch (*c) {
                     case '\'':
                     case '"':
@@ -733,12 +749,14 @@ void tokenize_c_macro(CTokenize *ctok, const uint8_t *c) {
                 }
                 break;
             case CTokStateLineComment:
+                assert(ctok->cur_tok != nullptr);
                 if (*c == '\n') {
                     ctok->state = CTokStateStart;
                     goto found_end_of_macro;
                 }
                 break;
             case CTokStateComment:
+                assert(ctok->cur_tok != nullptr);
                 switch (*c) {
                     case '*':
                         ctok->state = CTokStateCommentStar;
@@ -748,6 +766,7 @@ void tokenize_c_macro(CTokenize *ctok, const uint8_t *c) {
                 }
                 break;
             case CTokStateCommentStar:
+                assert(ctok->cur_tok != nullptr);
                 switch (*c) {
                     case '/':
                         ctok->state = CTokStateStart;
@@ -760,6 +779,7 @@ void tokenize_c_macro(CTokenize *ctok, const uint8_t *c) {
                 }
                 break;
             case CTokStateBackslash:
+                assert(ctok->cur_tok != nullptr);
                 switch (*c) {
                     case '\n':
                         ctok->state = CTokStateStart;
@@ -784,10 +804,12 @@ found_end_of_macro:
         case CTokStateNumLitIntSuffixL:
         case CTokStateNumLitIntSuffixUL:
         case CTokStateNumLitIntSuffixLL:
+            assert(ctok->cur_tok != nullptr);
             end_token(ctok);
             break;
         case CTokStateFloat:
         case CTokStateFloatExp:
+            assert(ctok->cur_tok != nullptr);
             end_float(ctok);
             break;
         case CTokStateExpectChar:
@@ -803,6 +825,7 @@ found_end_of_macro:
         case CTokStateFloatExpFirst:
         case CTokStateStrHex:
         case CTokStateStrOctal:
+            assert(ctok->cur_tok != nullptr);
             return mark_error(ctok);
     }
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4306,7 +4306,7 @@ static LLVMValueRef get_coro_alloc_helper_fn_val(CodeGen *g, LLVMTypeRef alloc_f
     LLVMValueRef alloc_fn_val = LLVMGetParam(fn_val, next_arg);
     next_arg += 1;
 
-    LLVMValueRef stack_trace_val;
+    LLVMValueRef stack_trace_val = nullptr;
     if (g->have_err_ret_tracing) {
         stack_trace_val = LLVMGetParam(fn_val, next_arg);
         next_arg += 1;
@@ -4317,7 +4317,6 @@ static LLVMValueRef get_coro_alloc_helper_fn_val(CodeGen *g, LLVMTypeRef alloc_f
     LLVMValueRef err_code_ptr = LLVMGetParam(fn_val, next_arg);
     next_arg += 1;
     LLVMValueRef coro_size = LLVMGetParam(fn_val, next_arg);
-    next_arg += 1;
     LLVMValueRef alignment_val = LLVMConstInt(g->builtin_types.entry_u29->type_ref,
             get_coro_frame_align_bytes(g), false);
 
@@ -5828,20 +5827,20 @@ static const uint8_t int_sizes_in_bits[] = {
 };
 
 struct CIntTypeInfo {
-    CIntType id;
     const char *name;
+    CIntType id;
     bool is_signed;
 };
 
 static const CIntTypeInfo c_int_type_infos[] = {
-    {CIntTypeShort, "c_short", true},
-    {CIntTypeUShort, "c_ushort", false},
-    {CIntTypeInt, "c_int", true},
-    {CIntTypeUInt, "c_uint", false},
-    {CIntTypeLong, "c_long", true},
-    {CIntTypeULong, "c_ulong", false},
-    {CIntTypeLongLong, "c_longlong", true},
-    {CIntTypeULongLong, "c_ulonglong", false},
+    {"c_short", CIntTypeShort, true},
+    {"c_ushort", CIntTypeUShort, false},
+    {"c_int", CIntTypeInt, true},
+    {"c_uint", CIntTypeUInt, false},
+    {"c_long", CIntTypeLong,true},
+    {"c_ulong", CIntTypeULong, false},
+    {"c_longlong", CIntTypeLongLong,  true},
+    {"c_ulonglong", CIntTypeULongLong, false},
 };
 
 static const bool is_signed_list[] = { false, true, };

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -12384,7 +12384,6 @@ static TypeTableEntry *ir_analyze_fn_call(IrAnalyze *ira, IrInstructionCall *cal
             }
         }
 
-        assert(new_fn_arg_count > 0);
         IrInstruction **casted_args = allocate<IrInstruction *>(new_fn_arg_count);
 
         // Fork a scope of the function with known values for the parameters.
@@ -17423,7 +17422,6 @@ static TypeTableEntry *ir_analyze_instruction_slice(IrAnalyze *ira, IrInstructio
 
         ConstExprValue *ptr_val = &out_val->data.x_struct.fields[slice_ptr_index];
 
-        assert(parent_ptr != nullptr);
         if (array_val) {
             size_t index = abs_offset + start_scalar;
             bool is_const = slice_is_const(return_type);
@@ -17440,26 +17438,28 @@ static TypeTableEntry *ir_analyze_instruction_slice(IrAnalyze *ira, IrInstructio
             ptr_val->type = get_pointer_to_type(ira->codegen, parent_ptr->type->data.pointer.child_type,
                     slice_is_const(return_type));
             ptr_val->special = ConstValSpecialUndef;
-        } else switch (parent_ptr->data.x_ptr.special) {
-            case ConstPtrSpecialInvalid:
-            case ConstPtrSpecialDiscard:
-                zig_unreachable();
-            case ConstPtrSpecialRef:
-                init_const_ptr_ref(ira->codegen, ptr_val,
-                        parent_ptr->data.x_ptr.data.ref.pointee, slice_is_const(return_type));
-                break;
-            case ConstPtrSpecialBaseArray:
-                zig_unreachable();
-            case ConstPtrSpecialBaseStruct:
-                zig_panic("TODO");
-            case ConstPtrSpecialHardCodedAddr:
-                init_const_ptr_hard_coded_addr(ira->codegen, ptr_val,
-                    parent_ptr->type->data.pointer.child_type,
-                    parent_ptr->data.x_ptr.data.hard_coded_addr.addr + start_scalar,
-                    slice_is_const(return_type));
-                break;
-            case ConstPtrSpecialFunction:
-                zig_panic("TODO");
+        } else {
+            switch (parent_ptr->data.x_ptr.special) {
+                case ConstPtrSpecialInvalid:
+                case ConstPtrSpecialDiscard:
+                    zig_unreachable();
+                case ConstPtrSpecialRef:
+                    init_const_ptr_ref(ira->codegen, ptr_val,
+                            parent_ptr->data.x_ptr.data.ref.pointee, slice_is_const(return_type));
+                    break;
+                case ConstPtrSpecialBaseArray:
+                    zig_unreachable();
+                case ConstPtrSpecialBaseStruct:
+                    zig_panic("TODO");
+                case ConstPtrSpecialHardCodedAddr:
+                    init_const_ptr_hard_coded_addr(ira->codegen, ptr_val,
+                        parent_ptr->type->data.pointer.child_type,
+                        parent_ptr->data.x_ptr.data.hard_coded_addr.addr + start_scalar,
+                        slice_is_const(return_type));
+                    break;
+                case ConstPtrSpecialFunction:
+                    zig_panic("TODO");
+            }
         }
 
         ConstExprValue *len_val = &out_val->data.x_struct.fields[slice_len_index];

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -205,6 +205,7 @@ static void ir_ref_bb(IrBasicBlock *bb) {
 }
 
 static void ir_ref_instruction(IrInstruction *instruction, IrBasicBlock *cur_bb) {
+    assert(instruction != nullptr);
     assert(instruction->id != IrInstructionIdInvalid);
     instruction->ref_count += 1;
     if (instruction->owner_bb != cur_bb && !instr_is_comptime(instruction))
@@ -12383,6 +12384,7 @@ static TypeTableEntry *ir_analyze_fn_call(IrAnalyze *ira, IrInstructionCall *cal
             }
         }
 
+        assert(new_fn_arg_count > 0);
         IrInstruction **casted_args = allocate<IrInstruction *>(new_fn_arg_count);
 
         // Fork a scope of the function with known values for the parameters.
@@ -17421,6 +17423,7 @@ static TypeTableEntry *ir_analyze_instruction_slice(IrAnalyze *ira, IrInstructio
 
         ConstExprValue *ptr_val = &out_val->data.x_struct.fields[slice_ptr_index];
 
+        assert(parent_ptr != nullptr);
         if (array_val) {
             size_t index = abs_offset + start_scalar;
             bool is_const = slice_is_const(return_type);
@@ -17433,6 +17436,7 @@ static TypeTableEntry *ir_analyze_instruction_slice(IrAnalyze *ira, IrInstructio
                 ptr_val->data.x_ptr.mut = parent_ptr->data.x_ptr.mut;
             }
         } else if (ptr_is_undef) {
+            assert(ptr_val != nullptr);
             ptr_val->type = get_pointer_to_type(ira->codegen, parent_ptr->type->data.pointer.child_type,
                     slice_is_const(return_type));
             ptr_val->special = ConstValSpecialUndef;
@@ -18395,7 +18399,9 @@ static void buf_write_value_bytes(CodeGen *codegen, uint8_t *buf, ConstExprValue
             {
                 size_t buf_i = 0;
                 expand_undef_array(codegen, val);
-                for (size_t elem_i = 0; elem_i < val->type->data.array.len; elem_i += 1) {
+                size_t elem_i = 0;
+                assert(elem_i < val->type->data.array.len);
+                for (; elem_i < val->type->data.array.len; elem_i += 1) {
                     ConstExprValue *elem = &val->data.x_array.s_none.elements[elem_i];
                     buf_write_value_bytes(codegen, &buf[buf_i], elem);
                     buf_i += type_size(codegen, elem->type);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1025,7 +1025,7 @@ static AstNode *ast_parse_fn_proto_partial(ParseContext *pc, size_t *token_index
     if (next_token->id == TokenIdKeywordVar) {
         node->data.fn_proto.return_var_token = next_token;
         *token_index += 1;
-        next_token = &pc->tokens->at(*token_index);
+        pc->tokens->at(*token_index);
     } else {
         if (next_token->id == TokenIdKeywordError) {
             Token *maybe_lbrace_tok = &pc->tokens->at(*token_index + 1);
@@ -1037,7 +1037,7 @@ static AstNode *ast_parse_fn_proto_partial(ParseContext *pc, size_t *token_index
         } else if (next_token->id == TokenIdBang) {
             *token_index += 1;
             node->data.fn_proto.auto_err_set = true;
-            next_token = &pc->tokens->at(*token_index);
+            pc->tokens->at(*token_index);
         }
         node->data.fn_proto.return_type = ast_parse_type_expr(pc, token_index, true);
     }


### PR DESCRIPTION
* Upgrade to >= CMake 3.1 (needed for Threads library and other modern CMake features).
* Use `CMAKE_CURRENT_(SOURCE|BINARY)_DIR` instead of `CMAKE_(SOURCE|BINARY)_DIR`.
* Run clang-tidy on Zig C++ sources. (Technically a CMake 3.6 feature but not upgrading minimum CMake just for this.) Can be enabled/disabled with `ENABLE_CLANG_TIDY` option. Added `.clang-tidy` file as config for this analysis.