### PR TITLE
build: add flag to LLD to fix gcc 8 build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,7 +196,7 @@ else()
     if(MSVC)
         set(ZIG_LLD_COMPILE_FLAGS "-std=c++11 -D_CRT_SECURE_NO_WARNINGS /w")
     else()
-        set(ZIG_LLD_COMPILE_FLAGS "-std=c++11 -fno-exceptions -fno-rtti -Wno-comment")
+        set(ZIG_LLD_COMPILE_FLAGS "-std=c++11 -fno-exceptions -fno-rtti -Wno-comment -Wno-class-memaccess")
     endif()
     set_target_properties(embedded_lld_lib PROPERTIES
         COMPILE_FLAGS ${ZIG_LLD_COMPILE_FLAGS}


### PR DESCRIPTION
AX31 on IRC posted this:

```
/home/axel/Projects/zig/zig/deps/lld/ELF/SymbolTable.cpp: In member function ‘void lld::elf::SymbolTable::applySymbolWrap()’:
/home/axel/Projects/zig/zig/deps/lld/ELF/SymbolTable.cpp:190:47: error: ‘void* memcpy(void*, const void*, size_t)’ writing to an object of type ‘class lld::elf::Symbol’ with no trivial copy-assignment; use copy-initialization instead [-Werror=class-memaccess]
       memcpy(Real, W.Real, sizeof(SymbolUnion));
                                               ^
In file included from /home/axel/Projects/zig/zig/deps/lld/ELF/SymbolTable.cpp:20:
/home/axel/Projects/zig/zig/deps/lld/ELF/Symbols.h:38:7: note: ‘class lld::elf::Symbol’ declared here
 class Symbol {
       ^~~~~~
```

This patch fixed it for them.

If this passes the tests on all platforms I'll merge.