### PR TITLE
add c type sizes for OpenBSD

### DIFF
--- a/src/target.cpp
+++ b/src/target.cpp
@@ -734,14 +734,6 @@ uint32_t target_c_type_size_in_bits(const ZigTarget *target, CIntType id) {
                 case CIntTypeCount:
                     zig_unreachable();
             }
-        case OsAnanas:
-        case OsCloudABI:
-        case OsDragonFly:
-        case OsFreeBSD:
-        case OsIOS:
-        case OsKFreeBSD:
-        case OsLv2:
-        case OsNetBSD:
         case OsOpenBSD:
             switch (id) {
                 case CIntTypeShort:
@@ -759,6 +751,14 @@ uint32_t target_c_type_size_in_bits(const ZigTarget *target, CIntType id) {
                 case CIntTypeCount:
                     zig_unreachable();
             }
+        case OsAnanas:
+        case OsCloudABI:
+        case OsDragonFly:
+        case OsFreeBSD:
+        case OsIOS:
+        case OsKFreeBSD:
+        case OsLv2:
+        case OsNetBSD:
         case OsSolaris:
         case OsHaiku:
         case OsMinix:

--- a/src/target.cpp
+++ b/src/target.cpp
@@ -743,6 +743,22 @@ uint32_t target_c_type_size_in_bits(const ZigTarget *target, CIntType id) {
         case OsLv2:
         case OsNetBSD:
         case OsOpenBSD:
+            switch (id) {
+                case CIntTypeShort:
+                case CIntTypeUShort:
+                    return 16;
+                case CIntTypeInt:
+                case CIntTypeUInt:
+                    return 32;
+                case CIntTypeLong:
+                case CIntTypeULong:
+                    return get_arch_pointer_bit_width(target->arch.arch);
+                case CIntTypeLongLong:
+                case CIntTypeULongLong:
+                    return 64;
+                case CIntTypeCount:
+                    zig_unreachable();
+            }
         case OsSolaris:
         case OsHaiku:
         case OsMinix:


### PR DESCRIPTION
Used 

``` c
#include <stdio.h>

int
main(void)
{
        printf("short      : %lu\n", sizeof(short));
        printf("ushort     : %lu\n", sizeof(unsigned short));
        printf("int        : %lu\n", sizeof(int));
        printf("uint       : %lu\n", sizeof(unsigned int));
        printf("long       : %lu\n", sizeof(long));
        printf("ulong      : %lu\n", sizeof(unsigned long));
        printf("long long  : %lu\n", sizeof(long long));
        printf("ulong long : %lu\n", sizeof(unsigned long long));
        printf("size_t     : %lu\n", sizeof(size_t));

        return 0;
}
```

to figure out the sizes.